### PR TITLE
stable/4.1 updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-pbr!=2.1.0,>=2.0.0 # Apache-2.0
+pbr!=2.1.0,>=2.0.0,<=5.8.0 # Apache-2.0
 cliff!=2.9.0,>=2.8.0 # Apache-2.0
 jsonschema<3.0.0,>=2.6.0
 testtools>=2.2.0 # MIT
@@ -9,7 +9,7 @@ paramiko>=2.0.0,<=2.8.0 # LGPLv2.1+
 netaddr>=0.7.18 # BSD
 oslo.concurrency>=3.26.0 # Apache-2.0
 oslo.config>=5.2.0 # Apache-2.0
-oslo.log>=3.36.0 # Apache-2.0
+oslo.log>=3.36.0,<=4.6.1 # Apache-2.0
 stestr>=1.0.0 # Apache-2.0
 oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0
 oslo.utils>=3.33.0 # Apache-2.0


### PR DESCRIPTION
Updated requirements of virtual environment to handle below error.
```
+ ./run_tempest.sh tempest.api.workloadmgr.license.test_create_license
python3
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
OSError: [Errno 9] Bad file descriptor
```