### PR TITLE
AUTO-50: automated test shared security group restore: OS-2028 and OS-2029

### DIFF
--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -1744,11 +1744,22 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
         LOG.debug("Port deletion for " + str(ports) + " started.")
         self.delete_ports(ports)
 
+    """
     '''create_security_group'''
 
     def create_security_group(self, name, description, secgrp_cleanup=True):
         self.security_group_id = self.security_groups_client.create_security_group(
             name=name, description=description)['security_group']['id']
+        if (tvaultconf.cleanup and secgrp_cleanup):
+            self.addCleanup(self.delete_security_group, self.security_group_id)
+        return self.security_group_id
+    """
+
+    '''create_security_group'''
+
+    def create_security_group(self, name, description, tenant_id=CONF.identity.tenant_id, secgrp_cleanup=True):
+        self.security_group_id = self.security_groups_client.create_security_group(
+            name=name, description=description, tenant_id=tenant_id)['security_group']['id']
         if (tvaultconf.cleanup and secgrp_cleanup):
             self.addCleanup(self.delete_security_group, self.security_group_id)
         return self.security_group_id
@@ -3985,4 +3996,3 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
         except Exception as e:
             LOG.error("Exception in add_security_group_to_instance: {}".format(e))
             return False
-

--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -1759,18 +1759,7 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
         LOG.debug("Port deletion for " + str(ports) + " started.")
         self.delete_ports(ports)
 
-    """
-    '''create_security_group'''
-
-    def create_security_group(self, name, description, secgrp_cleanup=True):
-        self.security_group_id = self.security_groups_client.create_security_group(
-            name=name, description=description)['security_group']['id']
-        if (tvaultconf.cleanup and secgrp_cleanup):
-            self.addCleanup(self.delete_security_group, self.security_group_id)
-        return self.security_group_id
-    """
-
-    '''create_security_group'''
+    '''create_security_group in same/another project'''
 
     def create_security_group(self, name, description, tenant_id=CONF.identity.tenant_id, secgrp_cleanup=True):
         self.security_group_id = self.security_groups_client.create_security_group(
@@ -3580,7 +3569,7 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
         self.delete_volumes(vol)
         for secgrp in secgrp_ids:
             self.delete_security_group(secgrp)
-            LOG.debug("Delete security groups: {}".format(secgrp))
+            LOG.debug("Deleted security groups: {}".format(secgrp))
 
     '''
     This method creates a secret for workloads
@@ -4011,3 +4000,18 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
         except Exception as e:
             LOG.error("Exception in add_security_group_to_instance: {}".format(e))
             return False
+
+    def get_restored_security_group_id_by_name(self, security_group_name):
+        security_group_id = ""
+        security_groups_list = self.security_groups_client.list_security_groups()[
+            'security_groups']
+        LOG.debug("Security groups list" + str(security_groups_list))
+        for security_group in security_groups_list:
+            if security_group['name'] == security_group_name and "Restored from original security group" in security_group['description']:
+                security_group_id = security_group['id']
+        if security_group_id != "":
+            LOG.debug("security group id for security group {}".format(security_group_id))
+            return security_group_id
+        else:
+            LOG.debug("security group id is NOT present/restored")
+            return None

--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -813,7 +813,7 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
             snapshot_id,
             restore_name="",
             restore_cleanup=True,
-            sec_group_cleanup=False):
+            sec_group_cleanup=True):
         LOG.debug("At the start of snapshot_restore method")
         if (restore_name == ""):
             restore_name = tvaultconf.snapshot_restore_name
@@ -877,7 +877,7 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
             network_details=[],
             network_restore_flag=False,
             restore_cleanup=True,
-            sec_group_cleanup=False):
+            sec_group_cleanup=True):
         LOG.debug("At the start of snapshot_selective_restore method")
         if (restore_name == ""):
             restore_name = "Tempest_test_restore"

--- a/tempest/api/workloadmgr/security_groups/test_security_group_default.py
+++ b/tempest/api/workloadmgr/security_groups/test_security_group_default.py
@@ -134,14 +134,17 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
     """ Method to create Security groups with distinct rules """
 
-    def _create_sec_groups_rule(self, security_group_names, data_sec_group_and_rules):
+    def _create_sec_groups_rule(self, security_group_names, data_sec_group_and_rules,
+                                tenant_id=CONF.identity.tenant_id):
         LOG.debug("Create security group and rule")
         created_security_groups = []
         for each in range(1, len(data_sec_group_and_rules) + 1):
             sgid = self.create_security_group(
                 name=security_group_names + format(each),
                 description="security group with distinct rules",
+                tenant_id=tenant_id,
                 secgrp_cleanup=True,
+                #secgrp_cleanup=False,
             )
             created_security_groups.append(sgid)
             # Delete default security group rules
@@ -160,7 +163,32 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
                 )
         return created_security_groups
 
-    def _security_group_and_rules_verification(self, security_group_names, data_sec_group_and_rules, rules_count):
+    def _security_group_verification_post_restore(self, restored_secgrps):
+        for restored_secgrp in restored_secgrps:
+            LOG.debug(
+                "Print names of restored security groups : {}".format(
+                    restored_secgrp["name"]
+                )
+            )
+            if self.verifySecurityGroupsByname(restored_secgrp["name"]):
+                reporting.add_test_step(
+                    "Security group verification successful for restored vm {}".format(
+                        restored_secgrp["name"]
+                    ),
+                    tvaultconf.PASS,
+                )
+            else:
+                reporting.add_test_step(
+                    "Security group verification failed for restored vm {}".format(
+                        restored_secgrp["name"]
+                    ),
+                    tvaultconf.FAIL,
+                )
+                reporting.set_test_script_status(tvaultconf.FAIL)
+
+    def _security_group_and_rules_verification(
+            self, security_group_names, data_sec_group_and_rules, rules_count
+    ):
         for t in range(0, len(data_sec_group_and_rules)):
             restored_security_group = security_group_names + str(t + 1)
             sgid = self.get_security_group_id_by_name(restored_security_group)
@@ -195,6 +223,73 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
                     tvaultconf.FAIL,
                 )
                 reporting.set_test_script_status(tvaultconf.FAIL)
+
+    def _perform_selective_restore(self, vms, volumes, workload_id, snapshot_id):
+        rest_details = {
+            "rest_type": "selective",
+            "network_id": CONF.network.internal_network_id,
+            "subnet_id": self.get_subnet_id(CONF.network.internal_network_id),
+            "instances": {vms[0]: volumes},
+        }
+
+        payload = self.create_restore_json(rest_details)
+        # Trigger selective restore of full snapshot
+        restore_id = self.snapshot_selective_restore(
+            workload_id,
+            snapshot_id,
+            restore_name=tvaultconf.selective_restore_name,
+            restore_cleanup=True,
+            instance_details=payload["instance_details"],
+            network_details=payload["network_details"],
+        )
+
+        if self.getRestoreStatus(workload_id, snapshot_id, restore_id) == "available":
+            reporting.add_test_step(
+                "Selective restore completed successfully", tvaultconf.PASS
+            )
+            LOG.debug("selective restore passed")
+        else:
+            reporting.add_test_step("Selective restore failed", tvaultconf.FAIL)
+            reporting.set_test_script_status(tvaultconf.FAIL)
+            LOG.error("selective restore failed")
+        return restore_id
+
+    def _perform_oneclick_restore(self, workload_id, snapshot_id):
+        restore_id = self.snapshot_restore(
+            workload_id, snapshot_id, restore_cleanup=True
+        )
+        self.wait_for_snapshot_tobe_available(workload_id, snapshot_id)
+        if (
+                self.getRestoreStatus(workload_id, snapshot_id, restore_id)
+                == "available"
+        ):
+            reporting.add_test_step(
+                "Oneclick restore completed successfully", tvaultconf.PASS
+            )
+            LOG.debug("Oneclick restore passed")
+        else:
+            LOG.error("Oneclick restore failed")
+            reporting.add_test_step(
+                "Oneclick restore failed", tvaultconf.FAIL)
+            reporting.set_test_script_status(tvaultconf.FAIL)
+        return restore_id
+
+    def _delete_vms_secgroups(self, vms, secgroup_ids):
+        try:
+            self.delete_vm_secgroups(vms, secgroup_ids)
+            reporting.add_test_step(
+                "Delete vms and security groups before proceeding with restore",
+                tvaultconf.PASS,
+            )
+            LOG.debug(
+                "Remaining security groups after deletion {} ".format(
+                    self.list_security_groups()
+                )
+            )
+        except Exception as e:
+            LOG.error(f"Exception: {e}")
+            raise Exception("Deletion of vms and security group/s failed")
+        time.sleep(60)
 
     # Test case automation for #OS-1892 : Security_Group_Restore_using_CLI_for_single_group
     # Test case automation for #OS-1893 : Security_Group_Restore_using_CLI_for_multiple_groups
@@ -306,6 +401,268 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
                 LOG.debug("Comparing restored security group & rules for {}".format(tvaultconf.security_group_name))
                 self._security_group_and_rules_verification(security_group_names, data_sec_group_and_rules, rules_count)
+
+            except Exception as e:
+                LOG.error("Exception: " + str(e))
+                reporting.add_test_step(str(e), tvaultconf.FAIL)
+                reporting.set_test_script_status(tvaultconf.FAIL)
+
+            finally:
+                reporting.test_case_to_write()
+                # Deleting restored security groups after verification
+                if len(self.restored_secgroup_ids) != 0:
+                    for secgrp in self.restored_secgroup_ids:
+                        LOG.debug("Deleting security groups: {}".format(secgrp))
+                        self.delete_security_group(secgrp)
+
+    # Test case automation for #OS-2028 : Shared Security_Group_Restore
+    @decorators.attr(type="workloadmgr_api")
+    def test_02_shared_security_group(self):
+        test_var = "tempest.api.workloadmgr.security_group.test_"
+        tests = [
+            [test_var + "shared_security_group_restore_delete_vm_secgrp_shared", 1, 3, "delete_vm_secgrp_shared"],
+            [test_var + "shared_security_group_restore_delete_vm_secgrp", 1, 3, "delete_vm_secgrp"],
+            [test_var + "shared_security_group_restore_delete_vm", 1, 3, "delete_vm"],
+            [test_var + "shared_security_group_restore_no_delete", 1, 3, "no_delete"],
+        ]
+        # tests = [[test_var + "shared_security_group_restore_no_delete", 1, 3, "no_delete"]]
+
+        tenant_id = CONF.identity.tenant_id
+        tenant_id_1 = CONF.identity.tenant_id_1
+        # user_id = CONF.identity.user_id
+        for test in tests:
+            reporting.add_test_script(test[0])
+            security_group_count = test[1]
+            rules_count = test[2]
+            LOG.debug("Create shared Security group/s with distinct rules")
+            try:
+                security_group_names_projA = tvaultconf.security_group_name + str(random.randint(0, 10000))
+                security_group_names_projB = tvaultconf.security_group_name + str(random.randint(0, 10000))
+                try:
+                    # create security group in project A (tenant_id_1)
+                    LOG.debug(
+                        "Setting project to project-A: {} and {}".format(CONF.identity.project_alt_name, tenant_id_1))
+                    data_sec_group_and_rules_tenantA = self._generate_data_for_secgrp(
+                        security_group_count, rules_count
+                    )
+                    security_groups_tenantA = self._create_sec_groups_rule(
+                        security_group_names_projA,
+                        data_sec_group_and_rules_tenantA,
+                        tenant_id_1
+                    )
+                    print("project A sec group id: {}".format(security_groups_tenantA[0]))
+                    reporting.add_test_step(
+                        "creating shared security group/s {} with distinct rules in project-A ".format(security_group_names_projA + str(1)),
+                        tvaultconf.PASS,
+                    )
+
+                    # Create the RBAC policy entry using the openstack network rbac create and share the above created security_group with project-B
+                    rbac_command = command_argument_string.rbac_create_secgroup + tenant_id + " --action access_as_shared --type security_group " + \
+                                   security_groups_tenantA[0]
+                    LOG.debug("rbac command: {}".format(rbac_command))
+                    rc = cli_parser.cli_returncode(rbac_command)
+                    if rc != 0:
+                        reporting.add_test_step(
+                            "Execute create rbac policy for security group",
+                            tvaultconf.FAIL,
+                        )
+                        raise Exception("rbac command did not execute correctly")
+                    else:
+                        reporting.add_test_step(
+                            "Execute create rbac policy for security group",
+                            tvaultconf.PASS,
+                        )
+                    time.sleep(10)
+
+                    # Create security group in project-B (tenant_id)
+                    LOG.debug("Setting project to project-B: {} and {}".format(CONF.identity.project_name, tenant_id))
+                    data_sec_group_and_rules_tenantB = self._generate_data_for_secgrp(
+                        security_group_count, rules_count
+                    )
+                    security_groups_tenantB = self._create_sec_groups_rule(
+                        security_group_names_projB,
+                        data_sec_group_and_rules_tenantB,
+                    )
+                    print("project B sec group id: {}".format(security_groups_tenantB[0]))
+
+                    # create security_group_rule for the sec_group created in above step, attach the remote-sec-group as the shared sec_group.
+                    LOG.debug("Create security group rule with shared security group")
+                    self.add_security_group_rule(
+                        parent_grp_id=security_groups_tenantB[0],
+                        remote_grp_id=security_groups_tenantA[0],
+                        ip_proto="tcp",
+                        from_prt=1567,
+                        to_prt=3269,
+                    )
+                    reporting.add_test_step(
+                        "creating security group/s {} with shared security group from project-A ".format(security_group_names_projA + str(1)),
+                        tvaultconf.PASS,
+                    )
+                except Exception as e:
+                    LOG.error(f"Exception: {e}")
+                    raise Exception("Shared security group and rules creation failed")
+
+                # Create an image booted instance with Security group and attach an volume.
+                LOG.debug(
+                    "Create an image booted instance with Security group and attach an volume"
+                )
+                # Create volume
+                self.volume_id = self.create_volume(volume_cleanup=True)
+                LOG.debug("Volume ID: " + str(self.volume_id))
+
+                # create vm
+                self.vm_id = self.create_vm(
+                    security_group_id=security_groups_tenantB[0], vm_cleanup=True
+                )
+                LOG.debug("Vm ID: " + str(self.vm_id))
+
+                # Attach volume to the instance
+                self.attach_volume(self.volume_id, self.vm_id, attach_cleanup=True)
+                LOG.debug("Volume attached")
+
+                # Create a workload for the instance.
+                LOG.debug("Create a workload for this instance.")
+                workload_id = self._create_workload([self.vm_id])
+                LOG.debug("\nWorkload created : {}\n".format(workload_id))
+
+                # Take a Full snapshot
+                LOG.debug("Take a full snapshot")
+                snapshot_id = self._take_full_snapshot(workload_id)
+
+                # Get the sec groups and rules list for verification post restore
+                secgroups_before = self.list_security_groups()
+                rules_before = self.list_security_group_rules()
+
+                # Delete security group assigned to instance as per the test steps
+                delete_secgrp_ids = []
+                if (test[3] == "delete_vm_secgrp"):
+                    delete_secgrp_ids = [security_groups_tenantB[0]]
+
+                # Delete security group assigned to instance and shared security group
+                if (test[3] == "delete_vm_secgrp_shared"):
+                    delete_secgrp_ids = [security_groups_tenantA[0], security_groups_tenantB[0]]
+
+                # Delete vm, volumes, security groups as per the test step
+                try:
+                    if (test[3] != "no_delete"):
+                        vol = []
+                        for vm in [self.vm_id]:
+                            LOG.debug("Get list of all volumes to be deleted from instance {}".format(vm))
+                            vol.append(self.get_attached_volumes(vm))
+                        self.delete_vms([self.vm_id])
+                        LOG.debug("Delete volumes: {}".format(vol))
+                        self.delete_volumes(vol)
+                        reporting.add_test_step("Deleted vm {} before proceeding with restore".format(self.vm_id),
+                                                tvaultconf.PASS, )
+                        time.sleep(10)
+
+                        if (delete_secgrp_ids is not None):
+                            for secgrp in delete_secgrp_ids:
+                                self.delete_security_group(secgrp)
+                                LOG.debug(
+                                    "Delete security group assigned to instance and shared security group: {}".format(
+                                        secgrp))
+                            reporting.add_test_step(
+                                "Deleted security groups/shared security group {} before proceeding with restore".format(
+                                    delete_secgrp_ids),
+                                tvaultconf.PASS, )
+
+                    """
+                    # Delete security group assigned to instance                
+                    if (test[3] == "delete_vm_secgrp"):
+                        delete_secgrp_ids = security_groups_tenantB[0]
+                        self.delete_security_group(delete_secgrp_ids)
+                        reporting.add_test_step(
+                          "Deleted security group {} assigned to instance before proceeding with restore".format(delete_secgrp_ids),
+                          tvaultconf.PASS,
+                      )
+
+                    # Delete security group assigned to instance and shared security group
+                    if (test[3] == "delete_vm_secgrp_shared"):
+                        delete_secgrp_ids= [security_groups_tenantA[0], security_groups_tenantB[0]]
+                        for secgrp in delete_secgrp_ids:
+                            self.delete_security_group(secgrp)
+                            LOG.debug("Delete security group assigned to instance and shared security group: {}".format(secgrp))
+                        reporting.add_test_step(
+                          "Deleted security groups/shared security group {} before proceeding with restore".format(delete_secgrp_ids),
+                          tvaultconf.PASS,
+                      )
+                      """
+                except Exception as e:
+                    LOG.error(f"Exception: {e}")
+                    raise Exception("Deletion of vms/security group/Shared security group failed")
+
+                # Perform restores - selective, oneclick
+                restore_tests = [[test[0] + "_selectiverestore_api", "selective"],
+                         [test[0] + "_oneclickrestore_api", "oneclick"]]
+                restore_id = ""
+                for restore_test in restore_tests:
+                    reporting.add_test_script(restore_test[0])
+                    restore = restore_test[1]
+                    LOG.debug("Perform {} restore".format(restore))
+                    if restore == "oneclick":
+                        restore_id = self._perform_oneclick_restore(workload_id, snapshot_id)
+                    elif restore == "selective":
+                        restore_id = self._perform_selective_restore([self.vm_id], self.volume_id, workload_id, snapshot_id)
+
+                    restored_vms = self.get_restored_vm_list(restore_id)
+                    LOG.debug("\nRestored vms : {}\n".format(restored_vms))
+
+                    # Security group and rules verification post restore
+                    LOG.debug("Compare the security groups before and after restore")
+                    secgroups_after = self.list_security_groups()
+                    if len(secgroups_after) == len(secgroups_before):
+                        reporting.add_test_step(
+                            "Security group verification pre and post restore",
+                            tvaultconf.PASS,
+                        )
+                    else:
+                        LOG.error("Security groups verification pre and post restore")
+                        reporting.add_test_step(
+                            "Security groups verification failed pre and post restore",
+                            tvaultconf.FAIL,
+                        )
+                        reporting.set_test_script_status(tvaultconf.FAIL)
+
+                    LOG.debug("Compare the security group rules before and after restore")
+                    rules_after = self.list_security_group_rules()
+                    if len(rules_after) == len(rules_before):
+                        reporting.add_test_step(
+                            "Security group rules verification pre and post restore",
+                            tvaultconf.PASS,
+                        )
+                    else:
+                        reporting.add_test_step(
+                            "Security group rules verification pre and post restore",
+                            tvaultconf.FAIL,
+                        )
+                        reporting.set_test_script_status(tvaultconf.FAIL)
+
+                    # Verify the security group & rules assigned to the restored instance
+                    LOG.debug(
+                        "Comparing restored security group & rules for {}".format(
+                            security_group_names_projB
+                        )
+                    )
+                    restored_secgrps = self.getRestoredSecGroupPolicies(restored_vms)
+                    LOG.debug(
+                        "Comparing security group & rules assigned to the restored instances."
+                    )
+                    self._security_group_verification_post_restore(restored_secgrps)
+                    self._security_group_and_rules_verification(
+                        security_group_names_projB, data_sec_group_and_rules_tenantB, rules_count
+                    )
+
+                    # Verify security group and rules for shared security group
+                    self._security_group_and_rules_verification(
+                        security_group_names_projA, data_sec_group_and_rules_tenantA, rules_count
+                    )
+
+                    # Delete restored vms and security groups created during earlier restore
+                    if restore_test != restore_tests[-1]:
+                        LOG.debug("deleting restored vm and restored security groups and rules")
+                        self._delete_vms_secgroups(restored_vms, self.restored_secgroup_ids)
+                        reporting.test_case_to_write()
 
             except Exception as e:
                 LOG.error("Exception: " + str(e))

--- a/tempest/api/workloadmgr/security_groups/test_security_group_default.py
+++ b/tempest/api/workloadmgr/security_groups/test_security_group_default.py
@@ -425,6 +425,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
                         self.delete_security_group(secgrp)
 
     # Test case automation for #OS-2028 : Shared Security_Group_Restore
+    # http://192.168.15.51/testlink/linkto.php?tprojectPrefix=OS&item=testcase&id=OS-2028
     @decorators.attr(type="workloadmgr_api")
     def test_02_shared_security_group(self):
         test_var = "tempest.api.workloadmgr.security_group.test_"

--- a/tempest/command_argument_string.py
+++ b/tempest/command_argument_string.py
@@ -79,3 +79,6 @@ quota_update = "workloadmgr project-allowed-quota-update "
 quota_list = "workloadmgr project-allowed-quota-list -f json "
 quota_show = "workloadmgr project-allowed-quota-show -f value "
 quota_delete = "workloadmgr project-allowed-quota-delete "
+
+#RBAC commands
+rbac_create_secgroup = "openstack network rbac create --target-project "


### PR DESCRIPTION
Automated test for shared security group restore
http://192.168.15.51/testlink/linkto.php?tprojectPrefix=OS&item=testcase&id=OS-2028
PFA the report.
Total 7 test cases automated as part of #OS-2028:
1. Selective restore of shared security group with no_delete
2. Selective restore of shared security group with delete_vm
3. Oneclick restore of shared security group with delete_vm
4. Selective restore of shared security group with delete_vm_secgrps
5. Oneclick restore of shared security group with delete_vm_secgrps
6. Selective restore of shared security group with delete_vm_secgrps_shared
7. Oneclick restore of shared security group with delete_vm_secgrps_shared

Test cases are failing due to defect: https://triliodata.atlassian.net/browse/TVAULT-4837
1. tempest.api.workloadmgr.security_group.test_shared_security_group_restore_delete_vm_secgrp_selectiverestore_api
2. tempest.api.workloadmgr.security_group.test_shared_security_group_restore_delete_vm_secgrp_oneclickrestore_api

[results-sharedsecgroup.pdf](https://github.com/trilioData/tempest/files/8822389/results-sharedsecgroup.pdf)
