### PR TITLE
stable/5.0 marked network topology restore to False in test_restore_with_blank_n…

### DIFF
--- a/tempest/api/workloadmgr/restore/test_glanceimage_restore.py
+++ b/tempest/api/workloadmgr/restore/test_glanceimage_restore.py
@@ -230,7 +230,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
     @decorators.attr(type='workloadmgr_api')
     def test_2_glanceimage_volume_booted_instance(self):
         try:
-            test_var = "tempest.api.workloadmgr.barbican.test_volume_booted_"
+            test_var = "tempest.api.workloadmgr.restore.test_volume_booted_"
             self.tests = [[test_var+"selective_restore_api", 0],
                     [test_var+"oneclickrestore_api", 0]]
             reporting.add_test_script(self.tests[0][0])

--- a/tempest/api/workloadmgr/restore/test_restore_with_blank_name.py
+++ b/tempest/api/workloadmgr/restore/test_restore_with_blank_name.py
@@ -249,7 +249,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
                        "oneclickrestore": False,
                        "openstack": {"instances": instance_details,
                                      "networks_mapping": {"networks": []},
-                                     "restore_topology": True},
+                                     "restore_topology": False},
                        "restore_type": "selective"}
 
 


### PR DESCRIPTION
…ame.py