### PR TITLE
Stable/4.1 AUTO-164 fixed network topology cleanup failure

### DIFF
--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -327,7 +327,8 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
             self.delete_port(server_id)
             body = self.servers_client.show_server(server_id)['server']
             self.servers_client.delete_server(server_id)
-            waiters.wait_for_server_termination(self.servers_client, server_id)
+            waiters.wait_for_server_termination(self.servers_client, server_id,
+                    ignore_error=True)
         except lib_exc.NotFound:
             return
 
@@ -1702,13 +1703,15 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
 
     def delete_port(self, server_id):
         ports = []
-        internal_network_name = str((list(self.get_vm_details(
-            server_id)['server']['addresses'].keys())[0]))
-        fixed_ip = str((self.get_vm_details(server_id)[
-                       'server']['addresses'][internal_network_name][0]['addr']))
-        ports.append(self.get_port_id(fixed_ip))
-        LOG.debug("Port deletion for " + str(ports) + " started.")
-        self.delete_ports(ports)
+        vm_details = self.get_vm_details(server_id)
+        if vm_details['server']['status'] != 'ERROR':
+            int_net_name = \
+                    str(list(vm_details['server']['addresses'].keys())[0])
+            fixed_ip = \
+                str(vm_details['server']['addresses'][int_net_name][0]['addr'])
+            ports.append(self.get_port_id(fixed_ip))
+            LOG.debug("Port deletion for " + str(ports) + " started.")
+            self.delete_ports(ports)
 
     '''create_security_group'''
 

--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -2919,17 +2919,17 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
         self.routers_client.add_router_interface(routers['Router-3'], subnet_id=subnets['PS-3'])
         self.routers_client.add_router_interface(routers['Router-2'], subnet_id=subnets['PS-4'])
         portid1 = self.ports_client.create_port(
-            **{'network_id': nets['Private-2'], 'fixed_ips': [{'ip_address': '10.10.2.4'}]})['port']['id']
+            **{'network_id': nets['Private-2'], 'fixed_ips': [{'ip_address': '10.10.2.14'}]})['port']['id']
         self.routers_client.add_router_interface(routers['Router-2'], port_id=portid1)
         portid2 = self.ports_client.create_port(
-            **{'network_id': nets['Private-2'], 'fixed_ips': [{'ip_address': '10.10.2.5'}]})['port']['id']
+            **{'network_id': nets['Private-2'], 'fixed_ips': [{'ip_address': '10.10.2.15'}]})['port']['id']
         portid3 = self.ports_client.create_port(
-            **{'network_id': nets['Private-2'], 'fixed_ips': [{'ip_address': '10.10.2.6'}]})['port']['id']
+            **{'network_id': nets['Private-2'], 'fixed_ips': [{'ip_address': '10.10.2.16'}]})['port']['id']
         self.routers_client.add_router_interface(routers['Router-4'], port_id=portid2)
         self.routers_client.add_router_interface(routers['Router-5'], port_id=portid3)
         self.routers_client.add_router_interface(routers['Router-4'], subnet_id=subnets['PS-5'])
         portid4 = self.ports_client.create_port(
-            **{'network_id': nets['Private-5'], 'fixed_ips': [{'ip_address': '10.10.5.3'}]})['port']['id']
+            **{'network_id': nets['Private-5'], 'fixed_ips': [{'ip_address': '10.10.5.13'}]})['port']['id']
         self.routers_client.add_router_interface(routers['Router-5'], port_id=portid4)
 
         for router_name, router_id in list(routers.items()):

--- a/tempest/api/workloadmgr/test_cleaner.py
+++ b/tempest/api/workloadmgr/test_cleaner.py
@@ -123,15 +123,6 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             except Exception:
                 pass
 
-    def _delete_secrets(self):
-        secrets = self.secret_client.list_secrets()['secrets']
-        for secret in secrets:
-            secret_uuid = secret['secret_ref'].split('/')[-1]
-            try:
-                self.delete_secret(secret_uuid)
-            except BaseException:
-                pass
-
     @classmethod
     def setup_clients(cls):
         super(WorkloadTest, cls).setup_clients()
@@ -155,8 +146,6 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             LOG.debug("\nsecurity groups deleted\n")
             self._delete_quotas()
             LOG.debug("\nWorkloadmgr quotas deleted\n")
-            self._delete_secrets()
-            LOG.debug("\nSecrets deleted\n")
 
         except Exception as e:
             LOG.error("Exception: " + str(e))

--- a/tempest/api/workloadmgr/test_cleaner.py
+++ b/tempest/api/workloadmgr/test_cleaner.py
@@ -21,7 +21,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
     credentials = ['primary']
 
-    def delete_restores(self, snapshot_id, workload_id):
+    def _delete_restores(self, snapshot_id, workload_id):
         rests = self.getRestoreList(snapshot_id)
         for res in rests:
             try:
@@ -29,27 +29,30 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             except BaseException:
                 pass
 
-    def delete_snapshots(self, workload_id):
+    def _delete_snapshots(self, workload_id):
         snaps = self.getSnapshotList(workload_id)
         for snap in snaps:
             try:
-                self.delete_restores(snap, workload_id)
+                snapshot_status = self.getSnapshotStatus(workload_id, snap)
+                if snapshot_status == 'mounted':
+                    self.unmount_snapshot(workload_id, snap)
+                self._delete_restores(snap, workload_id)
                 self.wait_for_workload_tobe_available(workload_id)
                 self.snapshot_delete(workload_id, snap)
             except BaseException:
                 pass
 
-    def delete_workloads(self):
+    def _delete_workloads(self):
         wls = self.getWorkloadList()
         for wl in wls:
             try:
-                self.delete_snapshots(wl)
+                self._delete_snapshots(wl)
                 self.wait_for_workload_tobe_available(wl)
                 self.workload_delete(wl)
             except BaseException:
                 pass
 
-    def delete_servers(self):
+    def _delete_servers(self):
         servers = self.servers_client.list_servers()['servers']
         servers = [server['id'] for server in servers]
         for server in servers:
@@ -57,8 +60,10 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
                 self.delete_vm(server)
             except BaseException:
                 pass
+        servers = self.servers_client.list_servers()['servers']
+        LOG.debug(f"vms list at end of delete_servers: {servers}")
 
-    def delete_volumes(self):
+    def _delete_volumes(self):
         volumes = self.volumes_client.list_volumes()['volumes']
         volumes = [volume['id'] for volume in volumes]
         for volume in volumes:
@@ -67,7 +72,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             except BaseException:
                 pass
 
-    def delete_keypairs(self):
+    def _delete_keypairs(self):
         kps = self.keypairs_client.list_keypairs()['keypairs']
         kps = [kp['keypair']['name'] for kp in kps]
         for kp in kps:
@@ -76,7 +81,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             except BaseException:
                 pass
 
-    def delete_policies(self):
+    def _delete_policies(self):
         policies = self.get_policy_list()
         for policy in policies:
             try:
@@ -84,7 +89,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             except BaseException:
                 pass
 
-    def delete_abandoned_ports(self):
+    def _delete_abandoned_ports(self):
         subnets = self.networks_client.show_network(
             CONF.network.internal_network_id)['network']['subnets']
         ports = self.ports_client.list_ports()['ports']
@@ -98,7 +103,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
                 except BaseException:
                     pass
 
-    def delete_securitygroups(self):
+    def _delete_securitygroups(self):
         sgs = self.security_groups_client.list_security_groups()[
             'security_groups']
         sgs = [sg['id'] for sg in sgs if sg['name'] != 'default']
@@ -108,7 +113,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             except BaseException:
                 pass
 
-    def delete_quotas(self):
+    def _delete_quotas(self):
         quotas = self.get_quota_list(CONF.identity.tenant_id)
         LOG.debug(quotas)
         qs = [qt['id'] for qt in quotas]
@@ -118,6 +123,15 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             except Exception:
                 pass
 
+    def _delete_secrets(self):
+        secrets = self.secret_client.list_secrets()['secrets']
+        for secret in secrets:
+            secret_uuid = secret['secret_ref'].split('/')[-1]
+            try:
+                self.delete_secret(secret_uuid)
+            except BaseException:
+                pass
+
     @classmethod
     def setup_clients(cls):
         super(WorkloadTest, cls).setup_clients()
@@ -125,22 +139,24 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
     @decorators.idempotent_id('9fe07175-912e-49a5-a629-5f52eeada4c9')
     def test_cleaner(self):
         try:
-            self.delete_workloads()
+            self._delete_workloads()
             LOG.debug("\nworkloads deleted\n")
-            self.delete_servers()
+            self._delete_servers()
             LOG.debug("\nvms deleted\n")
-            self.delete_volumes()
+            self._delete_volumes()
             LOG.debug("\nvolumes deleted\n")
-            self.delete_keypairs()
+            self._delete_keypairs()
             LOG.debug("\nkeypairs deleted\n")
-            self.delete_policies()
+            self._delete_policies()
             LOG.debug("\npolicies deleted\n")
-            self.delete_abandoned_ports()
+            self._delete_abandoned_ports()
             LOG.debug("\nAbandoned ports deleted\n")
-            self.delete_securitygroups()
+            self._delete_securitygroups()
             LOG.debug("\nsecurity groups deleted\n")
-            self.delete_quotas()
+            self._delete_quotas()
             LOG.debug("\nWorkloadmgr quotas deleted\n")
+            self._delete_secrets()
+            LOG.debug("\nSecrets deleted\n")
 
         except Exception as e:
             LOG.error("Exception: " + str(e))


### PR DESCRIPTION
Fixed network topology prerequisite failure in cleanup. These changes are already part of 4.2 and 5.0 branches. Backporting the fixes to 4.1
Local test run result:
![image](https://user-images.githubusercontent.com/17542895/178314520-f6226333-196c-4319-a900-f99236a8ac64.png)
