### PR TITLE
Auto-175 - Auomated test for #OS-1752

### DIFF
--- a/tempest/api/workloadmgr/barbican/test_barbican.py
+++ b/tempest/api/workloadmgr/barbican/test_barbican.py
@@ -179,6 +179,8 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                         "booted vm")
 
             reporting.add_test_script(tests[1][0])
+            full_snapshot_sizes = []
+            incr_snapshot_sizes = []
             self.snapshot_id = self.workload_snapshot(self.wid, True)
             self.wait_for_workload_tobe_available(self.wid)
             self.snapshot_status = self.getSnapshotStatus(self.wid,
@@ -192,8 +194,14 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     reporting.add_test_step("Verify snapshot existence on "\
                             "target backend", tvaultconf.PASS)
                     self._check_encryption_on_backend(self.wid, self.snapshot_id,
-                            self.vm_id, self.disk_names, self.mount_path)
-
+                                                      self.vm_id, self.disk_names, self.mount_path)
+                    for disk_name in self.disk_names:
+                        full_snapshot_size = int(
+                            self.check_snapshot_size_on_backend(self.mount_path, self.wid, self.snapshot_id,
+                                                                self.vm_id, disk_name))
+                        LOG.debug(f"full snapshot_size for {disk_name}: {full_snapshot_size} MB")
+                        full_snapshot_sizes.append({disk_name: full_snapshot_size})
+                    LOG.debug(f"Full snapshot sizes for all disks: {full_snapshot_sizes}")
                     tests[1][1] = 1
                     reporting.test_case_to_write()
                 else:
@@ -221,8 +229,23 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     reporting.add_test_step("Verify snapshot existence on "\
                             "target backend", tvaultconf.PASS)
                     self._check_encryption_on_backend(self.wid, self.snapshot_id2,
-                            self.vm_id, self.disk_names, self.mount_path)
-
+                                                      self.vm_id, self.disk_names, self.mount_path)
+                    for disk_name in self.disk_names:
+                        incr_snapshot_size = int(
+                            self.check_snapshot_size_on_backend(self.mount_path, self.wid, self.snapshot_id2,
+                                                                self.vm_id, disk_name))
+                        LOG.debug(f"incr snapshot_size for {disk_name}: {incr_snapshot_size} MB")
+                        incr_snapshot_sizes.append({disk_name: incr_snapshot_size})
+                    LOG.debug(f"Incr snapshot sizes for all disks: {incr_snapshot_sizes}")
+                    for dict1, dict2 in zip(full_snapshot_sizes, incr_snapshot_sizes):
+                        for key, value in dict1.items():
+                            LOG.debug(f"All values: {dict1} {dict2} {value} {dict2[key]}")
+                            if value > dict2[key]:
+                                reporting.add_test_step(
+                                    f"Full snapshot size is greater than incr snapshot size for {key}", tvaultconf.PASS)
+                            else:
+                                reporting.add_test_step(
+                                    f"Full snapshot size is greater than incr snapshot size for {key}", tvaultconf.FAIL)
                     tests[2][1] = 1
                     reporting.test_case_to_write()
                 else:
@@ -677,6 +700,8 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                         "booted vm and vol attached")
 
             reporting.add_test_script(tests[1][0])
+            full_snapshot_sizes = []
+            incr_snapshot_sizes = []
             self.snapshot_id = self.workload_snapshot(self.wid, True)
             self.wait_for_workload_tobe_available(self.wid)
             self.snapshot_status = self.getSnapshotStatus(self.wid,
@@ -690,8 +715,14 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     reporting.add_test_step("Verify snapshot existence on "\
                             "target backend", tvaultconf.PASS)
                     self._check_encryption_on_backend(self.wid, self.snapshot_id,
-                            self.vm_id, self.disk_names, self.mount_path)
-
+                                                      self.vm_id, self.disk_names, self.mount_path)
+                    for disk_name in self.disk_names:
+                        full_snapshot_size = int(
+                            self.check_snapshot_size_on_backend(self.mount_path, self.wid, self.snapshot_id,
+                                                                self.vm_id, disk_name))
+                        LOG.debug(f"full snapshot_size for {disk_name}: {full_snapshot_size} MB")
+                        full_snapshot_sizes.append({disk_name: full_snapshot_size})
+                    LOG.debug(f"Full snapshot sizes for all disks: {full_snapshot_sizes}")
                     tests[1][1] = 1
                     reporting.test_case_to_write()
                 else:
@@ -718,8 +749,23 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     reporting.add_test_step("Verify snapshot existence on "\
                             "target backend", tvaultconf.PASS)
                     self._check_encryption_on_backend(self.wid, self.snapshot_id2,
-                            self.vm_id, self.disk_names, self.mount_path)
-
+                                                      self.vm_id, self.disk_names, self.mount_path)
+                    for disk_name in self.disk_names:
+                        incr_snapshot_size = int(
+                            self.check_snapshot_size_on_backend(self.mount_path, self.wid, self.snapshot_id2,
+                                                                self.vm_id, disk_name))
+                        LOG.debug(f"incr snapshot_size for {disk_name}: {incr_snapshot_size} MB")
+                        incr_snapshot_sizes.append({disk_name: incr_snapshot_size})
+                    LOG.debug(f"Incr snapshot sizes for all disks: {incr_snapshot_sizes}")
+                    for dict1, dict2 in zip(full_snapshot_sizes, incr_snapshot_sizes):
+                        for key, value in dict1.items():
+                            LOG.debug(f"All values: {dict1} {dict2} {value} {dict2[key]}")
+                            if value > dict2[key]:
+                                reporting.add_test_step(
+                                    f"Full snapshot size is greater than incr snapshot size for {key}", tvaultconf.PASS)
+                            else:
+                                reporting.add_test_step(
+                                    f"Full snapshot size is greater than incr snapshot size for {key}", tvaultconf.FAIL)
                     tests[2][1] = 1
                     reporting.test_case_to_write()
                 else:
@@ -1089,7 +1135,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 self.execute_command_disk_mount(ssh, fip[0],
                         tvaultconf.volumes_parts, tvaultconf.mount_points)
                 time.sleep(5)
-                md5sums_after_full_oneclick = self._get_md5sum(ssh, ["/opt", "volumes"]) 
+                md5sums_after_full_oneclick = self._get_md5sum(ssh, ["/opt", "volumes"])
                 LOG.debug(f"md5sums_after_full_oneclick: {md5sums_after_full_oneclick}")
                 ssh.close()
 
@@ -1239,6 +1285,8 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                         "booted vm")
 
             reporting.add_test_script(tests[1][0])
+            full_snapshot_sizes = []
+            incr_snapshot_sizes = []
             self.snapshot_id = self.workload_snapshot(self.wid, True)
             self.wait_for_workload_tobe_available(self.wid)
             self.snapshot_status = self.getSnapshotStatus(self.wid,
@@ -1252,8 +1300,14 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     reporting.add_test_step("Verify snapshot existence on "\
                             "target backend", tvaultconf.PASS)
                     self._check_encryption_on_backend(self.wid, self.snapshot_id,
-                            self.vm_id, self.disk_names, self.mount_path)
-
+                                                      self.vm_id, self.disk_names, self.mount_path)
+                    for disk_name in self.disk_names:
+                        full_snapshot_size = int(
+                            self.check_snapshot_size_on_backend(self.mount_path, self.wid, self.snapshot_id,
+                                                                self.vm_id, disk_name))
+                        LOG.debug(f"full snapshot_size for {disk_name}: {full_snapshot_size} MB")
+                        full_snapshot_sizes.append({disk_name: full_snapshot_size})
+                    LOG.debug(f"Full snapshot sizes for all disks: {full_snapshot_sizes}")
                     tests[1][1] = 1
                     reporting.test_case_to_write()
                 else:
@@ -1281,8 +1335,23 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     reporting.add_test_step("Verify snapshot existence on "\
                             "target backend", tvaultconf.PASS)
                     self._check_encryption_on_backend(self.wid, self.snapshot_id2,
-                            self.vm_id, self.disk_names, self.mount_path)
-
+                                                      self.vm_id, self.disk_names, self.mount_path)
+                    for disk_name in self.disk_names:
+                        incr_snapshot_size = int(
+                            self.check_snapshot_size_on_backend(self.mount_path, self.wid, self.snapshot_id2,
+                                                                self.vm_id, disk_name))
+                        LOG.debug(f"incr snapshot_size for {disk_name}: {incr_snapshot_size} MB")
+                        incr_snapshot_sizes.append({disk_name: incr_snapshot_size})
+                    LOG.debug(f"Incr snapshot sizes for all disks: {incr_snapshot_sizes}")
+                    for dict1, dict2 in zip(full_snapshot_sizes, incr_snapshot_sizes):
+                        for key, value in dict1.items():
+                            LOG.debug(f"All values: {dict1} {dict2} {value} {dict2[key]}")
+                            if value > dict2[key]:
+                                reporting.add_test_step(
+                                    f"Full snapshot size is greater than incr snapshot size for {key}", tvaultconf.PASS)
+                            else:
+                                reporting.add_test_step(
+                                    f"Full snapshot size is greater than incr snapshot size for {key}", tvaultconf.FAIL)
                     tests[2][1] = 1
                     reporting.test_case_to_write()
                 else:
@@ -1754,6 +1823,8 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                         "booted vm and vol attached")
 
             reporting.add_test_script(tests[1][0])
+            full_snapshot_sizes = 0
+            incr_snapshot_sizes = 0
             self.snapshot_id = self.workload_snapshot(self.wid, True)
             self.wait_for_workload_tobe_available(self.wid)
             self.snapshot_status = self.getSnapshotStatus(self.wid,
@@ -1767,8 +1838,14 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     reporting.add_test_step("Verify snapshot existence on "\
                             "target backend", tvaultconf.PASS)
                     self._check_encryption_on_backend(self.wid, self.snapshot_id,
-                            self.vm_id, self.disk_names, self.mount_path)
-
+                                                      self.vm_id, self.disk_names, self.mount_path)
+                    for disk_name in self.disk_names:
+                        full_snapshot_size = int(
+                            self.check_snapshot_size_on_backend(self.mount_path, self.wid, self.snapshot_id,
+                                                                self.vm_id, disk_name))
+                        LOG.debug(f"full snapshot_size for {disk_name}: {full_snapshot_size} MB")
+                        full_snapshot_sizes = full_snapshot_sizes + full_snapshot_size
+                    LOG.debug(f"Full snapshot sizes for all disks: {full_snapshot_sizes}")
                     tests[1][1] = 1
                     reporting.test_case_to_write()
                 else:
@@ -1798,8 +1875,20 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     reporting.add_test_step("Verify snapshot existence on "\
                             "target backend", tvaultconf.PASS)
                     self._check_encryption_on_backend(self.wid, self.snapshot_id2,
-                            self.vm_id, self.disk_names, self.mount_path)
-
+                                                      self.vm_id, self.disk_names, self.mount_path)
+                    for disk_name in self.disk_names:
+                        incr_snapshot_size = int(
+                            self.check_snapshot_size_on_backend(self.mount_path, self.wid, self.snapshot_id2,
+                                                                self.vm_id, disk_name))
+                        LOG.debug(f"incr snapshot_size for {disk_name}: {incr_snapshot_size} MB")
+                        incr_snapshot_sizes = incr_snapshot_sizes + incr_snapshot_size
+                    LOG.debug(f"Incr snapshot sizes for all disks: {incr_snapshot_sizes}")
+                    if (full_snapshot_sizes > incr_snapshot_sizes):
+                        reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size",
+                                                tvaultconf.PASS)
+                    else:
+                        reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size",
+                                                tvaultconf.FAIL)
                     tests[2][1] = 1
                     reporting.test_case_to_write()
                 else:
@@ -4097,7 +4186,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                         self.delete_restored_vms(restored_vms, restored_volumes)
                         self.restore_delete(wid, snapshot_id, restore_id)
                         reporting.add_test_step("Deleted restored vms and volumes", tvaultconf.PASS)
-                        
+
                         # DB validations for selective restore after restore deletion
                         restore_validations_after_deletion = self.db_cleanup_restore_validations(restore_id)
                         if (all(value == 0 for value in restore_validations_after_deletion.values())):
@@ -4115,7 +4204,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                         LOG.debug("triliovault created snapshots are not deleted after deleting snapshots")
                     else:
                         raise Exception("triliovault created snapshots should not be deleted after deleting snapshots")
-                    
+
                     # DB validations for snapshots after deletion
                     snapshot_validations_after_deletion = self.db_cleanup_snapshot_validations(snapshot_id)
                     if (all(value == 0 for value in snapshot_validations_after_deletion.values())):
@@ -4123,7 +4212,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     else:
                         reporting.add_test_step("selective: db cleanup validations for snapshot ", tvaultconf.FAIL)
                         reporting.set_test_script_status(tvaultconf.FAIL)
-                    
+
                     # Delete workloads and verify
                     self.workload_delete(wid)
                     time.sleep(30)
@@ -4134,7 +4223,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                                                 tvaultconf.PASS)
                     else:
                         raise Exception("triliovault created snapshots are NOT deleted after workload deletion")
-                    
+
                     # DB validations for workload after workload deletion
                     workload_validations_after_deletion = self.db_cleanup_workload_validations(wid)
                     if (all(value == 0 for value in workload_validations_after_deletion.values())):
@@ -4197,7 +4286,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     else:
                         raise Exception(
                             "triliovault created snapshots for in_place restore are deleted after deleting workload snapshots")
-                    
+
                     # DB validations for snapshots after deletion
                     snapshot_validations_after_deletion = self.db_cleanup_snapshot_validations(snapshot_id)
                     if (all(value == 0 for value in snapshot_validations_after_deletion.values())):
@@ -4205,7 +4294,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     else:
                         reporting.add_test_step("inplace: db cleanup validations for snapshot ", tvaultconf.FAIL)
                         reporting.set_test_script_status(tvaultconf.FAIL)
-                        
+
                     # Delete workloads and verify
                     self.workload_delete(wid)
                     time.sleep(30)
@@ -4216,7 +4305,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     else:
                         reporting.add_test_step("inplace: db cleanup validations for workload ", tvaultconf.FAIL)
                         reporting.set_test_script_status(tvaultconf.FAIL)
-                    
+
                     trilio_vol_snapshots_after = self.get_trilio_volume_snapshot(vol_snap_name_for_inplace)
                     LOG.debug("Inplace restore - trilio_vol_snapshots_before : {}".format(trilio_vol_snapshots_before))
                     LOG.debug("Inplace restore - trilio_vol_snapshots_after : {}".format(trilio_vol_snapshots_after))
@@ -4296,7 +4385,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     else:
                         reporting.add_test_step("oneclick: db cleanup validations for snapshot ", tvaultconf.FAIL)
                         reporting.set_test_script_status(tvaultconf.FAIL)
-                    
+
                     # Delete workloads and verify
                     self.workload_delete(wid)
                     time.sleep(30)
@@ -4307,7 +4396,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     else:
                         reporting.add_test_step("oneclick: db cleanup validations for workload ", tvaultconf.FAIL)
                         reporting.set_test_script_status(tvaultconf.FAIL)
-                    
+
                     trilio_vol_snapshots_after = self.get_trilio_volume_snapshot(vol_snap_name)
                     if trilio_vol_snapshots_after != trilio_vol_snapshots_before:
                         LOG.debug("triliovault created snapshots are still present")
@@ -4626,7 +4715,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
 
 
     # OS-2026
-    # Test case automated #AUTO-53 for verification of secret key added to secret container. 
+    # Test case automated #AUTO-53 for verification of secret key added to secret container.
     # http://192.168.15.51/testlink/linkto.php?tprojectPrefix=OS&item=testcase&id=OS-2026
     @decorators.attr(type='workloadmgr_api')
     def test_19_barbican(self):
@@ -4681,7 +4770,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 raise Exception("Create secret container with secret_href.")
 
             reporting.test_case_to_write()
- 
+
             reporting.add_test_script(tests[1][0])
             # Create workload with CLI to pass secret uuid.
             workload_create_cmd = command_argument_string.workload_create_with_encryption + \

--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -4473,4 +4473,22 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
         LOG.debug("command executed: " + str(output))
         return output
 
+    '''
+    Method returns True if snapshot dir is exists on backup target media
+    '''
 
+    def check_snapshot_size_on_backend(self, mount_path,
+            workload_id, snapshot_id):
+        snapshot_size = 0
+        cmd = tvaultconf.command_prefix + "ls -l " + str(mount_path).strip() + \
+                "/workload_" + str(workload_id).strip() + "/snapshot_" + \
+                str(snapshot_id).strip() + " | cut -d ' ' -f 5"
+        p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        LOG.debug(f"stdout: {stdout}; stderr: {stderr}")
+        if str(stderr).find('No such file or directory') != -1:
+            return snapshot_size
+        else:
+            snapshot_size = str(stdout)
+            return snapshot_size

--- a/tempest/api/workloadmgr/restore/test_image_vol.py
+++ b/tempest/api/workloadmgr/restore/test_image_vol.py
@@ -133,7 +133,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
                       str(md5sums_before_full))
 
             workload_create = command_argument_string.workload_create + \
-                " --instance instance-id=" + str(vm_id)
+                              " --instance instance-id=" + str(vm_id) + " --jobschedule enabled=False"
             rc = cli_parser.cli_returncode(workload_create)
             if rc != 0:
                 reporting.add_test_step(
@@ -166,6 +166,17 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
             snapshot_id = self.create_snapshot(workload_id, is_full=True)
 
+            mount_path = self.get_mountpoint_path()
+            disk_names = ["vda", "vdb"]
+            full_snapshot_sizes = []
+            incr_snapshot_sizes = []
+            for disk_name in disk_names:
+                full_snapshot_size = int(self.check_snapshot_size_on_backend(mount_path, workload_id,
+                                                                             snapshot_id, vm_id, disk_name))
+                LOG.debug(f"full snapshot_size for {disk_name}: {full_snapshot_size} MB")
+                full_snapshot_sizes.append({disk_name: full_snapshot_size})
+            LOG.debug(f"Full snapshot sizes for all disks: {full_snapshot_sizes}")
+
             # Add some more data to files on VM
             ssh = self.SshRemoteMachineConnectionWithRSAKey(str(floating_ip_1))
             self.addCustomfilesOnLinuxVM(ssh, mount_points[0], 2)
@@ -179,6 +190,21 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             ### Incremental snapshot ###
 
             incr_snapshot_id = self.create_snapshot(workload_id, is_full=False)
+
+            for disk_name in disk_names:
+                incr_snapshot_size = int(self.check_snapshot_size_on_backend(mount_path, workload_id,
+                                                                             incr_snapshot_id, vm_id, disk_name))
+                LOG.debug(f"incr snapshot_size for {disk_name}: {incr_snapshot_size} MB")
+                incr_snapshot_sizes.append({disk_name: incr_snapshot_size})
+            LOG.debug(f"Incr snapshot sizes for all disks: {incr_snapshot_sizes}")
+            for dict1, dict2 in zip(full_snapshot_sizes, incr_snapshot_sizes):
+                for key, value in dict1.items():
+                    if value > dict2[key]:
+                        reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size for {key}",
+                                                tvaultconf.PASS)
+                    else:
+                        reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size for {key}",
+                                                tvaultconf.FAIL)
 
             # Post snapshot, we need to wait on workload to be available on some setups
             self.wait_for_workload_tobe_available(workload_id)

--- a/tempest/api/workloadmgr/restore/test_volume_booted.py
+++ b/tempest/api/workloadmgr/restore/test_volume_booted.py
@@ -141,7 +141,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
                       str(md5sums_before_full))
 
             workload_create = command_argument_string.workload_create + \
-                " --instance instance-id=" + str(vm_id)
+                              " --instance instance-id=" + str(vm_id) + " --jobschedule enabled=False"
             rc = cli_parser.cli_returncode(workload_create)
             if rc != 0:
                 reporting.add_test_step(
@@ -172,6 +172,17 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
             snapshot_id = self.create_snapshot(workload_id, is_full=True)
 
+            mount_path = self.get_mountpoint_path()
+            disk_names = ["vda"]
+            full_snapshot_sizes = []
+            incr_snapshot_sizes = []
+            for disk_name in disk_names:
+                full_snapshot_size = int(self.check_snapshot_size_on_backend(mount_path, workload_id,
+                                                                             snapshot_id, vm_id, disk_name))
+                LOG.debug(f"full snapshot_size for {disk_name}: {full_snapshot_size} MB")
+                full_snapshot_sizes.append({disk_name: full_snapshot_size})
+            LOG.debug(f"Full snapshot sizes for all disks: {full_snapshot_sizes}")
+
             # Add some more data to files on VM
             ssh = self.SshRemoteMachineConnectionWithRSAKey(str(floating_ip_1))
             self.addCustomfilesOnLinuxVM(ssh, data_dir_path, 2)
@@ -185,6 +196,21 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             ### Incremental snapshot ###
 
             incr_snapshot_id = self.create_snapshot(workload_id, is_full=False)
+
+            for disk_name in disk_names:
+                incr_snapshot_size = int(self.check_snapshot_size_on_backend(mount_path, workload_id,
+                                                                             incr_snapshot_id, vm_id, disk_name))
+                LOG.debug(f"incr snapshot_size for {disk_name}: {incr_snapshot_size} MB")
+                incr_snapshot_sizes.append({disk_name: incr_snapshot_size})
+            LOG.debug(f"Incr snapshot sizes for all disks: {incr_snapshot_sizes}")
+            for dict1, dict2 in zip(full_snapshot_sizes, incr_snapshot_sizes):
+                for key, value in dict1.items():
+                    if value > dict2[key]:
+                        reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size for {key}",
+                                                tvaultconf.PASS)
+                    else:
+                        reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size for {key}",
+                                                tvaultconf.FAIL)
 
             ### Selective restore ###
 

--- a/tempest/api/workloadmgr/restore/test_volume_vol.py
+++ b/tempest/api/workloadmgr/restore/test_volume_vol.py
@@ -159,7 +159,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
                 md5sums_before_full))
 
             workload_create = command_argument_string.workload_create + \
-                " --instance instance-id=" + str(vm_id)
+                              " --instance instance-id=" + str(vm_id) + " --jobschedule enabled=False"
             rc = cli_parser.cli_returncode(workload_create)
             if rc != 0:
                 reporting.add_test_step(
@@ -190,6 +190,17 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
             snapshot_id = self.create_snapshot(workload_id, is_full=True)
 
+            mount_path = self.get_mountpoint_path()
+            disk_names = ["vda", "vdb"]
+            full_snapshot_sizes = []
+            incr_snapshot_sizes = []
+            for disk_name in disk_names:
+                full_snapshot_size = int(self.check_snapshot_size_on_backend(mount_path, workload_id,
+                                                                             snapshot_id, vm_id, disk_name))
+                LOG.debug(f"full snapshot_size for {disk_name}: {full_snapshot_size} MB")
+                full_snapshot_sizes.append({disk_name: full_snapshot_size})
+            LOG.debug(f"Full snapshot sizes for all disks: {full_snapshot_sizes}")
+
             # Add some more data to files on VM
             ssh = self.SshRemoteMachineConnectionWithRSAKey(str(floating_ip_1))
             self.addCustomfilesOnLinuxVM(ssh, mount_points[0], 2)
@@ -203,6 +214,22 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             ### Incremental snapshot ###
 
             incr_snapshot_id = self.create_snapshot(workload_id, is_full=False)
+
+            for disk_name in disk_names:
+                incr_snapshot_size = int(self.check_snapshot_size_on_backend(mount_path, workload_id,
+                                                                             incr_snapshot_id, vm_id, disk_name))
+                LOG.debug(f"incr snapshot_size for {disk_name}: {incr_snapshot_size} MB")
+                incr_snapshot_sizes.append({disk_name: incr_snapshot_size})
+            LOG.debug(f"Incr snapshot sizes for all disks: {incr_snapshot_sizes}")
+            for dict1, dict2 in zip(full_snapshot_sizes, incr_snapshot_sizes):
+                for key, value in dict1.items():
+                    LOG.debug(f"All values: {dict1} {dict2} {value} {dict2[key]}")
+                    if value > dict2[key]:
+                        reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size for {key}",
+                                                tvaultconf.PASS)
+                    else:
+                        reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size for {key}",
+                                                tvaultconf.FAIL)
 
             ### Selective restore ###
 

--- a/tempest/api/workloadmgr/snapshot/test_snapshot_mount.py
+++ b/tempest/api/workloadmgr/snapshot/test_snapshot_mount.py
@@ -400,8 +400,8 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 raise Exception("Create workload with image " \
                                 "booted vm")
 
-            full_snapshot_size = 0
-            incr_snapshot_size = 0
+            full_snapshot_sizes = []
+            incr_snapshot_sizes = []
             self.snapshot_id = self.workload_snapshot(self.wid, True)
             self.wait_for_workload_tobe_available(self.wid)
             self.snapshot_status = self.getSnapshotStatus(self.wid,
@@ -415,9 +415,12 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on " \
                                             "target backend", tvaultconf.PASS)
-                    full_snapshot_size = self.check_snapshot_size_on_backend(self.mount_path, self.wid,
-                                                                             self.snapshot_id)
-                    LOG.debug(f"full snapshot_size: {full_snapshot_size}")
+                    for disk_name in self.disk_names:
+                        full_snapshot_size = self.check_snapshot_size_on_backend(self.mount_path, self.wid,
+                                                                                 self.snapshot_id, self.vm_id, disk_name)
+                        LOG.debug(f"full snapshot_size for {disk_name}: {full_snapshot_size} MB")
+                        full_snapshot_sizes.append({disk_name: full_snapshot_size})
+                    LOG.debug(f"Full snapshot sizes for all disks: {full_snapshot_sizes}")
                 else:
                     raise Exception("Verify snapshot existence on target backend")
             else:
@@ -442,13 +445,18 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on " \
                                             "target backend", tvaultconf.PASS)
-                    incr_snapshot_size = self.check_snapshot_size_on_backend(self.mount_path, self.wid,
-                                                                             self.snapshot_id)
-                    LOG.debug(f"incr snapshot_size: {incr_snapshot_size}")
-                    if (full_snapshot_size > incr_snapshot_size):
-                        reporting.add_test_step("Full snapshot size is greater than incr snapshot size", tvaultconf.PASS)
-                    else:
-                        reporting.add_test_step("Full snapshot size is greater than incr snapshot size", tvaultconf.FAIL)
+                    for disk_name in self.disk_names:
+                        incr_snapshot_size = self.check_snapshot_size_on_backend(self.mount_path, self.wid,
+                                                                             self.snapshot_id2, self.vm_id, disk_name)
+                        LOG.debug(f"incr snapshot_size for {disk_name}: {incr_snapshot_size} MB")
+                        incr_snapshot_sizes.append({disk_name: incr_snapshot_size})
+                    LOG.debug(f"Incr snapshot sizes for all disks: {incr_snapshot_sizes}")
+                    for dict1, dict2 in zip(full_snapshot_sizes, incr_snapshot_sizes):
+                        for key, value in dict1.items():
+                            if value > dict2[key]:
+                                reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size for {key}", tvaultconf.PASS)
+                            else:
+                                reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size for {key}", tvaultconf.FAIL)
                 else:
                     raise Exception("Verify snapshot existence on target backend")
             else:

--- a/tempest/api/workloadmgr/snapshot/test_snapshot_mount.py
+++ b/tempest/api/workloadmgr/snapshot/test_snapshot_mount.py
@@ -400,8 +400,8 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 raise Exception("Create workload with image " \
                                 "booted vm")
 
-            full_snapshot_size = 0
-            incr_snapshot_size = 0
+            full_snapshot_sizes = []
+            incr_snapshot_sizes = []
             self.snapshot_id = self.workload_snapshot(self.wid, True)
             self.wait_for_workload_tobe_available(self.wid)
             self.snapshot_status = self.getSnapshotStatus(self.wid,
@@ -415,9 +415,12 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on " \
                                             "target backend", tvaultconf.PASS)
-                    full_snapshot_size = self.check_snapshot_size_on_backend(self.mount_path, self.wid,
-                                                                             self.snapshot_id)
-                    LOG.debug(f"full snapshot_size: {full_snapshot_size}")
+                    for disk_name in self.disk_names:
+                        full_snapshot_size = self.check_snapshot_size_on_backend(self.mount_path, self.wid,
+                                                                                 self.snapshot_id, self.vm_id, disk_name)
+                        LOG.debug(f"full snapshot_size for {disk_name}: {full_snapshot_size}")
+                        full_snapshot_sizes.append({disk_name: full_snapshot_size})
+                    LOG.debug(f"Full snapshot sizes for all disks: {full_snapshot_sizes}")
                 else:
                     raise Exception("Verify snapshot existence on target backend")
             else:
@@ -442,13 +445,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on " \
                                             "target backend", tvaultconf.PASS)
-                    incr_snapshot_size = self.check_snapshot_size_on_backend(self.mount_path, self.wid,
-                                                                             self.snapshot_id)
-                    LOG.debug(f"incr snapshot_size: {incr_snapshot_size}")
-                    if (full_snapshot_size > incr_snapshot_size):
-                        reporting.add_test_step("Full snapshot size is greater than incr snapshot size", tvaultconf.PASS)
-                    else:
-                        reporting.add_test_step("Full snapshot size is greater than incr snapshot size", tvaultconf.FAIL)
+                    for disk_name in self.disk_names:
+                        incr_snapshot_size = self.check_snapshot_size_on_backend(self.mount_path, self.wid,
+                                                                             self.snapshot_id, self.vm_id, disk_name)
+                        LOG.debug(f"incr snapshot_size for {disk_name}: {incr_snapshot_size}")
+                        incr_snapshot_sizes.append({disk_name: incr_snapshot_size})
+                    LOG.debug(f"Incr snapshot sizes for all disks: {incr_snapshot_sizes}")
+                    for dict1, dict2 in zip(full_snapshot_sizes, incr_snapshot_sizes):
+                        for key, value in dict1.items():
+                            if value > dict2[key]:
+                                #print(key, value, dict2[key])
+                                reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size for {key}", tvaultconf.PASS)
+                            else:
+                                reporting.add_test_step(f"Full snapshot size is greater than incr snapshot size for {key}", tvaultconf.FAIL)
                 else:
                     raise Exception("Verify snapshot existence on target backend")
             else:

--- a/tempest/api/workloadmgr/snapshot/test_snapshot_mount.py
+++ b/tempest/api/workloadmgr/snapshot/test_snapshot_mount.py
@@ -400,6 +400,8 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 raise Exception("Create workload with image " \
                                 "booted vm")
 
+            full_snapshot_size = 0
+            incr_snapshot_size = 0
             self.snapshot_id = self.workload_snapshot(self.wid, True)
             self.wait_for_workload_tobe_available(self.wid)
             self.snapshot_status = self.getSnapshotStatus(self.wid,
@@ -413,6 +415,9 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on " \
                                             "target backend", tvaultconf.PASS)
+                    full_snapshot_size = self.check_snapshot_size_on_backend(self.mount_path, self.wid,
+                                                                             self.snapshot_id)
+                    LOG.debug(f"full snapshot_size: {full_snapshot_size}")
                 else:
                     raise Exception("Verify snapshot existence on target backend")
             else:
@@ -437,7 +442,13 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on " \
                                             "target backend", tvaultconf.PASS)
-
+                    incr_snapshot_size = self.check_snapshot_size_on_backend(self.mount_path, self.wid,
+                                                                             self.snapshot_id)
+                    LOG.debug(f"incr snapshot_size: {incr_snapshot_size}")
+                    if (full_snapshot_size > incr_snapshot_size):
+                        reporting.add_test_step("Full snapshot size is greater than incr snapshot size", tvaultconf.PASS)
+                    else:
+                        reporting.add_test_step("Full snapshot size is greater than incr snapshot size", tvaultconf.FAIL)
                 else:
                     raise Exception("Verify snapshot existence on target backend")
             else:


### PR DESCRIPTION
PFA the reports.
Added snapshot size validations.

1. tempest.api.workloadmgr.snapshot.test_image_booted_fvm_snapshot_mount_invalid_cli
2. tempest.api.workloadmgr.snapshot.test_snapshots_create_incremental_snapshot
3. tempest.api.workloadmgr.restore.test_volume_vol_Selective-restore
4. tempest.api.workloadmgr.restore.test_volume_booted_Selective-restore
5. tempest.api.workloadmgr.restore.test_image_booted_Selective-restore
6. tempest.api.workloadmgr.restore.test_image_vol_Selective-restore
7. tempest.api.workloadmgr.barbican.test_image_booted_incremental_snapshot_api
8. tempest.api.workloadmgr.barbican.test_image_boot_vol_attach_incremental_snapshot_api
9. tempest.api.workloadmgr.barbican.test_volume_booted_incremental_snapshot_api
10. tempest.api.workloadmgr.barbican.test_volume_boot_vol_attach_incremental_snapshot_api

[results-snapshot_size-final.pdf](https://github.com/trilioData/tempest/files/9988667/results-snapshot_size-final.pdf)
