### PR TITLE
Auto-248 Canonical fixes for barbican and multi-attach_volumes suite failures - stable/4.2

### DIFF
--- a/fetch_resources.sh
+++ b/fetch_resources.sh
@@ -376,7 +376,7 @@ function configure_tempest
         mysql_leader_pod=`ssh $CANONICAL_NODE_IP "juju status | grep 'mysql-innodb' | grep 'R/W' | head -1 | xargs | cut -d ' ' -f 1 | tr -d '*'"`
         mysql_ip=`ssh $CANONICAL_NODE_IP "juju status | grep 'mysql-innodb' | grep 'R/W' | head -1 | xargs | cut -d ' ' -f 5"`
         mysql_root_pwd=`ssh $CANONICAL_NODE_IP "juju run --unit $mysql_leader_pod leader-get | grep mysql.passwd | cut -d ' ' -f 2"`
-        command_prefix='ssh $CANONICAL_NODE_IP "juju ssh trilio-wlm/leader" -- '
+        command_prefix="ssh $CANONICAL_NODE_IP juju ssh trilio-wlm/leader -- "
         echo "mysql_leader_pod: "$mysql_leader_pod
         echo "mysql_ip: "$mysql_ip
         echo "mysql_root_pwd: "$mysql_root_pwd

--- a/fetch_resources.sh
+++ b/fetch_resources.sh
@@ -376,6 +376,7 @@ function configure_tempest
         mysql_leader_pod=`ssh $CANONICAL_NODE_IP "juju status | grep 'mysql-innodb' | grep 'R/W' | head -1 | xargs | cut -d ' ' -f 1 | tr -d '*'"`
         mysql_ip=`ssh $CANONICAL_NODE_IP "juju status | grep 'mysql-innodb' | grep 'R/W' | head -1 | xargs | cut -d ' ' -f 5"`
         mysql_root_pwd=`ssh $CANONICAL_NODE_IP "juju run --unit $mysql_leader_pod leader-get | grep mysql.passwd | cut -d ' ' -f 2"`
+        command_prefix='ssh $CANONICAL_NODE_IP "juju ssh trilio-wlm/leader" -- '
         echo "mysql_leader_pod: "$mysql_leader_pod
         echo "mysql_ip: "$mysql_ip
         echo "mysql_root_pwd: "$mysql_root_pwd
@@ -647,7 +648,10 @@ EOF
     sed -i "/user_frm_data = /c user_frm_data = \"$TEMPEST_FRM_FILE\"" $TEMPEST_TVAULTCONF
     sed -i '/tvault_version = /c tvault_version = "'$tvault_version'"' $TEMPEST_TVAULTCONF
     sed -i '/trustee_role = /c trustee_role = "'$TRUSTEE_ROLE'"' $TEMPEST_TVAULTCONF
-
+    if [[ ${OPENSTACK_DISTRO,,} == 'canonical'* ]]
+    then
+        echo 'command_prefix = "'$command_prefix'"' >> $TEMPEST_TVAULTCONF
+    fi
 }
 
 

--- a/tempest/api/workloadmgr/barbican/test_barbican.py
+++ b/tempest/api/workloadmgr/barbican/test_barbican.py
@@ -40,7 +40,10 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 vm_id, disk_names, mount_path):
         encrypted = False
         for disk_name in disk_names:
-            snapshot_encrypted = self.check_snapshot_encryption_on_backend(
+            if tvaultconf.command_prefix:
+                snapshot_encrypted = self.check_snapshot_encryption_on_backend_from_pod(mount_path, wid, snapshot_id, vm_id, disk_name)
+            else:
+                snapshot_encrypted = self.check_snapshot_encryption_on_backend(
                             tvaultconf.tvault_ip[0],
                             tvaultconf.tvault_username,
                             tvaultconf.tvault_password,
@@ -145,10 +148,17 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     self.snapshot_id)
             if(self.snapshot_status == "available"):
                 reporting.add_test_step("Create full snapshot", tvaultconf.PASS)
-                self.mount_path = self.get_mountpoint_path(
+                if tvaultconf.command_prefix:
+                    self.mount_path = self.get_mountpoint_path_from_pod()
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id)
+                else:
+                    self.mount_path = self.get_mountpoint_path(
                         tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
                         tvaultconf.tvault_password)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
                         tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
                         tvaultconf.tvault_password, self.mount_path,
                         self.wid, self.snapshot_id)
@@ -179,13 +189,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     self.snapshot_id2)
             if(self.snapshot_status == "available"):
                 reporting.add_test_step("Create incremental snapshot", tvaultconf.PASS)
-                self.mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, self.mount_path,
-                        self.wid, self.snapshot_id2)
+                if tvaultconf.command_prefix:
+                    self.mount_path = self.get_mountpoint_path_from_pod()
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id2)
+                else:
+                    self.mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, self.mount_path,
+                            self.wid, self.snapshot_id2)
                 LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on "\
@@ -673,13 +689,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     self.snapshot_id)
             if(self.snapshot_status == "available"):
                 reporting.add_test_step("Create full snapshot", tvaultconf.PASS)
-                self.mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, self.mount_path,
-                        self.wid, self.snapshot_id)
+                if tvaultconf.command_prefix:
+                    self.mount_path = self.get_mountpoint_path_from_pod()
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id)
+                else:
+                    self.mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, self.mount_path,
+                            self.wid, self.snapshot_id)
                 LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on "\
@@ -711,13 +733,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     self.snapshot_id2)
             if(self.snapshot_status == "available"):
                 reporting.add_test_step("Create incremental snapshot", tvaultconf.PASS)
-                self.mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, self.mount_path,
-                        self.wid, self.snapshot_id2)
+                if tvaultconf.command_prefix:
+                    self.mount_path = self.get_mountpoint_path_from_pod()
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id2)
+                else:
+                    self.mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, self.mount_path,
+                            self.wid, self.snapshot_id2)
                 LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on "\
@@ -1289,13 +1317,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     self.snapshot_id)
             if(self.snapshot_status == "available"):
                 reporting.add_test_step("Create full snapshot", tvaultconf.PASS)
-                self.mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, self.mount_path,
-                        self.wid, self.snapshot_id)
+                if tvaultconf.command_prefix:
+                    self.mount_path = self.get_mountpoint_path_from_pod()
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id)
+                else:
+                    self.mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, self.mount_path,
+                            self.wid, self.snapshot_id)
                 LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on "\
@@ -1323,13 +1357,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     self.snapshot_id2)
             if(self.snapshot_status == "available"):
                 reporting.add_test_step("Create incremental snapshot", tvaultconf.PASS)
-                self.mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, self.mount_path,
-                        self.wid, self.snapshot_id2)
+                if tvaultconf.command_prefix:
+                    self.mount_path = self.get_mountpoint_path_from_pod()
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id2)
+                else:
+                    self.mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, self.mount_path,
+                            self.wid, self.snapshot_id2)
                 LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on "\
@@ -1834,13 +1874,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     self.snapshot_id)
             if(self.snapshot_status == "available"):
                 reporting.add_test_step("Create full snapshot", tvaultconf.PASS)
-                self.mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, self.mount_path,
-                        self.wid, self.snapshot_id)
+                if tvaultconf.command_prefix:
+                    self.mount_path = self.get_mountpoint_path_from_pod()
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id)
+                else:
+                    self.mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, self.mount_path,
+                            self.wid, self.snapshot_id)
                 LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on "\
@@ -1872,13 +1918,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     self.snapshot_id2)
             if(self.snapshot_status == "available"):
                 reporting.add_test_step("Create incremental snapshot", tvaultconf.PASS)
-                self.mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, self.mount_path,
-                        self.wid, self.snapshot_id2)
+                if tvaultconf.command_prefix:
+                    self.mount_path = self.get_mountpoint_path_from_pod()
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id2)
+                else:
+                    self.mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, self.mount_path,
+                            self.wid, self.snapshot_id2)
                 LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on "\
@@ -2751,18 +2803,25 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
 
             # Check first snapshot is deleted from backup target when retention
             # value exceed
-            mount_path = self.get_mountpoint_path(
-                ipaddress=tvaultconf.tvault_ip[0],
-                username=tvaultconf.tvault_username,
-                password=tvaultconf.tvault_password)
-            LOG.debug("Backup target mount_path is : " + mount_path)
-            is_snapshot_exist = self.check_snapshot_exist_on_backend(
-                tvaultconf.tvault_ip[0],
-                tvaultconf.tvault_username,
-                tvaultconf.tvault_password,
-                mount_path,
-                self.workload_id,
-                deleted_snapshot_id)
+            mount_path = ""
+            if tvaultconf.command_prefix:
+                mount_path = self.get_mountpoint_path_from_pod()
+                LOG.debug("Backup target mount_path is : " + mount_path)
+                is_snapshot_exist = self.check_snapshot_exist_on_backend_from_pod(
+                    mount_path, self.workload_id, deleted_snapshot_id)
+            else:
+                mount_path = self.get_mountpoint_path(
+                    ipaddress=tvaultconf.tvault_ip[0],
+                    username=tvaultconf.tvault_username,
+                    password=tvaultconf.tvault_password)
+                LOG.debug("Backup target mount_path is : " + mount_path)
+                is_snapshot_exist = self.check_snapshot_exist_on_backend(
+                    tvaultconf.tvault_ip[0],
+                    tvaultconf.tvault_username,
+                    tvaultconf.tvault_password,
+                    mount_path,
+                    self.workload_id,
+                    deleted_snapshot_id)
             LOG.debug("Snapshot does not exist : %s" % is_snapshot_exist)
             if not is_snapshot_exist:
                 LOG.debug("First snapshot is deleted from backup target")
@@ -3684,13 +3743,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     self.snapshot_id)
             if(self.snapshot_status == "available"):
                 reporting.add_test_step("Create full snapshot", tvaultconf.PASS)
-                self.mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, self.mount_path,
-                        self.wid, self.snapshot_id)
+                if tvaultconf.command_prefix:
+                    self.mount_path = self.get_mountpoint_path_from_pod()
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id)
+                else:
+                    self.mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, self.mount_path,
+                            self.wid, self.snapshot_id)
                 LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on "\
@@ -3718,13 +3783,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                     self.snapshot_id2)
             if(self.snapshot_status == "available"):
                 reporting.add_test_step("Create incremental snapshot", tvaultconf.PASS)
-                self.mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, self.mount_path,
-                        self.wid, self.snapshot_id2)
+                if tvaultconf.command_prefix:
+                    self.mount_path = self.get_mountpoint_path_from_pod()
+                    LOG.debug("Backup target mount_path is : " + self.mount_path)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id2)
+                else:
+                    self.mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, self.mount_path,
+                            self.wid, self.snapshot_id2)
                 LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on "\
@@ -4198,13 +4269,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 snapshot_status = self.getSnapshotStatus(wid, snapshot_id)
                 if (snapshot_status == "available"):
                     reporting.add_test_step("Create full snapshot", tvaultconf.PASS)
-                    mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                    snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, mount_path,
-                        wid, snapshot_id)
+                    if tvaultconf.command_prefix:
+                        mount_path = self.get_mountpoint_path_from_pod()
+                        LOG.debug("Backup target mount_path is : " + mount_path)
+                        snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                            mount_path, wid, snapshot_id)
+                    else:
+                        mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                        snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, mount_path,
+                            wid, snapshot_id)
                     LOG.debug(f"snapshot_found: {snapshot_found}")
                     if snapshot_found:
                         reporting.add_test_step("Verify snapshot existence on " \
@@ -4492,13 +4569,19 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                 snapshot_status = self.getSnapshotStatus(wid, snapshot_id)
                 if (snapshot_status == "available"):
                     reporting.add_test_step("Create full snapshot", tvaultconf.PASS)
-                    mount_path = self.get_mountpoint_path(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password)
-                    snapshot_found = self.check_snapshot_exist_on_backend(
-                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                        tvaultconf.tvault_password, mount_path,
-                        wid, snapshot_id)
+                    if tvaultconf.command_prefix:
+                        mount_path = self.get_mountpoint_path_from_pod()
+                        LOG.debug("Backup target mount_path is : " + mount_path)
+                        snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                            mount_path, wid, snapshot_id)
+                    else:
+                        mount_path = self.get_mountpoint_path(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password)
+                        snapshot_found = self.check_snapshot_exist_on_backend(
+                            tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                            tvaultconf.tvault_password, mount_path,
+                            wid, snapshot_id)
                     LOG.debug(f"snapshot_found: {snapshot_found}")
                     if snapshot_found:
                         reporting.add_test_step("Verify snapshot existence on " \

--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -2809,6 +2809,22 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
         return str(mountpoint_path)
 
     '''
+    Method returns mountpoint path of backup target media from pods/container
+    '''
+
+    def get_mountpoint_path_from_pod(self):
+        cmd = tvaultconf.command_prefix + "mount"
+        p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        mountpoint_path = None
+        for line in stdout.splitlines():
+            if str(line).find('triliovault-mounts') != -1:
+                mountpoint_path = str(line).split()[2]
+        LOG.debug("mountpoint path is : " + str(mountpoint_path))
+        return str(mountpoint_path)
+
+    '''
     Method returns True if snapshot dir is exists on backup target media
     '''
 
@@ -2834,6 +2850,24 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
             return True
         else:
             return False
+
+    '''
+     Method returns True if snapshot dir is exists on backup target media on pods/containers
+     '''
+
+    def check_snapshot_exist_on_backend_from_pod(self, mount_path,
+                                        workload_id, snapshot_id):
+        cmd = tvaultconf.command_prefix + "ls " + str(mount_path).strip() + \
+              "/workload_" + str(workload_id).strip() + "/snapshot_" + \
+              str(snapshot_id).strip()
+        p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        LOG.debug(f"stdout: {stdout}; stderr: {stderr}")
+        if str(stderr).find('No such file or directory') != -1:
+            return False
+        else:
+            return True
 
     '''
     Method to return policies list assigned to particular project

--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -23,6 +23,8 @@ import re
 import collections
 import base64
 import io
+import subprocess
+import shlex
 
 from oslo_log import log as logging
 from tempest import config

--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -4003,6 +4003,37 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
             return False
 
     '''
+    Method returns True if snapshot is marked as encrypted on backup target media
+    '''
+
+    def check_snapshot_encryption_on_backend_from_pod(
+            self,
+            mount_path,
+            workload_id,
+            snapshot_id,
+            instance_id,
+            disk_name):
+        disk_path = str(mount_path).strip() + "/workload_" + \
+                        str(workload_id).strip() + "/snapshot_" + \
+                        str(snapshot_id).strip() + "/vm_id_" + \
+                        str(instance_id).strip() + "/vm_res_id*_" + \
+                        str(disk_name) + "/*"
+        is_snapshot_encrypted = "qemu-img info " + disk_path +\
+                " | grep -q encrypted && echo 'exists' ||echo 'not exists'"
+        LOG.debug("snapshot command is : " + str(is_snapshot_encrypted))
+        cmd = tvaultconf.command_prefix + is_snapshot_encrypted
+        p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        LOG.debug(f"stdout: {stdout}; stderr: {stderr}")
+        snapshot_encrypt = stdout.read().decode('utf-8').strip()
+        LOG.debug(f"is snapshot encrypted command output: {snapshot_encrypt}")
+        if str(snapshot_encrypt) == 'exists':
+            return True
+        else:
+            return False
+
+    '''
     List WLM trusts
     '''
 

--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -4026,7 +4026,7 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
                              stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
         LOG.debug(f"stdout: {stdout}; stderr: {stderr}")
-        snapshot_encrypt = stdout.read().decode('utf-8').strip()
+        snapshot_encrypt = stdout.decode('utf-8').strip('\n')
         LOG.debug(f"is snapshot encrypted command output: {snapshot_encrypt}")
         if str(snapshot_encrypt) == 'exists':
             return True

--- a/tempest/api/workloadmgr/multiattach_volumes/test_multiattach_volumes.py
+++ b/tempest/api/workloadmgr/multiattach_volumes/test_multiattach_volumes.py
@@ -390,16 +390,26 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
             self.wait_for_workload_tobe_available(self.wid)
             self.snapshot_status = self.getSnapshotStatus(self.wid,
                                                           self.snapshot_id)
-            self.mount_path = self.get_mountpoint_path(
-                tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                tvaultconf.tvault_password)
+            if tvaultconf.command_prefix:
+                self.mount_path = self.get_mountpoint_path_from_pod()
+                LOG.debug("Backup target mount_path is : " + self.mount_path)
+            else:
+                self.mount_path = self.get_mountpoint_path(
+                    tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                    tvaultconf.tvault_password)
+                LOG.debug("Backup target mount_path is : " + self.mount_path)
             if (self.snapshot_status == "available"):
                 reporting.add_test_step("Create full snapshot", tvaultconf.PASS)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                    tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                    tvaultconf.tvault_password, self.mount_path,
-                    self.wid, self.snapshot_id)
-                LOG.debug(f"snapshot_found: {self.snapshot_found}")
+                if tvaultconf.command_prefix:
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id)
+                    LOG.debug("Snapshot found : %s" % self.snapshot_found)
+                else:
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                        tvaultconf.tvault_password, self.mount_path,
+                        self.wid, self.snapshot_id)
+                    LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on target backend", tvaultconf.PASS)
 
@@ -421,11 +431,16 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                                                           self.snapshot_id2)
             if (self.snapshot_status == "available"):
                 reporting.add_test_step("Create incremental snapshot", tvaultconf.PASS)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                    tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                    tvaultconf.tvault_password, self.mount_path,
-                    self.wid, self.snapshot_id2)
-                LOG.debug(f"snapshot_found: {self.snapshot_found}")
+                if tvaultconf.command_prefix:
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id2)
+                    LOG.debug("Snapshot found : %s" % self.snapshot_found)
+                else:
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                        tvaultconf.tvault_password, self.mount_path,
+                        self.wid, self.snapshot_id2)
+                    LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on target backend", tvaultconf.PASS)
 
@@ -636,15 +651,25 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
             self.wait_for_workload_tobe_available(self.wid)
             self.snapshot_status = self.getSnapshotStatus(self.wid,
                                                           self.snapshot_id)
-            self.mount_path = self.get_mountpoint_path(tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                                                       tvaultconf.tvault_password)
+            if tvaultconf.command_prefix:
+                self.mount_path = self.get_mountpoint_path_from_pod()
+                LOG.debug("Backup target mount_path is : " + self.mount_path)
+            else:
+                self.mount_path = self.get_mountpoint_path(tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                    tvaultconf.tvault_password)
+                LOG.debug("Backup target mount_path is : " + self.mount_path)
             if (self.snapshot_status == "available"):
                 reporting.add_test_step("Create full snapshot", tvaultconf.PASS)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                    tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                    tvaultconf.tvault_password, self.mount_path,
-                    self.wid, self.snapshot_id)
-                LOG.debug(f"snapshot_found: {self.snapshot_found}")
+                if tvaultconf.command_prefix:
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id)
+                    LOG.debug("Snapshot found : %s" % self.snapshot_found)
+                else:
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                        tvaultconf.tvault_password, self.mount_path,
+                        self.wid, self.snapshot_id)
+                    LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on target backend", tvaultconf.PASS)
 
@@ -666,11 +691,16 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                                                           self.snapshot_id2)
             if (self.snapshot_status == "available"):
                 reporting.add_test_step("Create incremental snapshot", tvaultconf.PASS)
-                self.snapshot_found = self.check_snapshot_exist_on_backend(
-                    tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
-                    tvaultconf.tvault_password, self.mount_path,
-                    self.wid, self.snapshot_id2)
-                LOG.debug(f"snapshot_found: {self.snapshot_found}")
+                if tvaultconf.command_prefix:
+                    self.snapshot_found = self.check_snapshot_exist_on_backend_from_pod(
+                        self.mount_path, self.wid, self.snapshot_id2)
+                    LOG.debug("Snapshot found : %s" % self.snapshot_found)
+                else:
+                    self.snapshot_found = self.check_snapshot_exist_on_backend(
+                        tvaultconf.tvault_ip[0], tvaultconf.tvault_username,
+                        tvaultconf.tvault_password, self.mount_path,
+                        self.wid, self.snapshot_id2)
+                    LOG.debug(f"snapshot_found: {self.snapshot_found}")
                 if self.snapshot_found:
                     reporting.add_test_step("Verify snapshot existence on target backend", tvaultconf.PASS)
 

--- a/tempest/api/workloadmgr/workload_policy/test_workload_policy.py
+++ b/tempest/api/workloadmgr/workload_policy/test_workload_policy.py
@@ -1035,19 +1035,27 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
             # Check first snapshot is deleted from backup target when retension
             # value exceed
-            mount_path = self.get_mountpoint_path(
-                ipaddress=tvaultconf.tvault_ip[0],
-                username=tvaultconf.tvault_username,
-                password=tvaultconf.tvault_password)
-            LOG.debug("Backup target mount_path is : " + mount_path)
-            is_snapshot_exist = self.check_snapshot_exist_on_backend(
-                tvaultconf.tvault_ip[0],
-                tvaultconf.tvault_username,
-                tvaultconf.tvault_password,
-                mount_path,
-                self .workload_id,
-                deleted_snapshot_id)
-            LOG.debug("Snapshot does not exist : %s" % is_snapshot_exist)
+            mount_path = ""
+            if tvaultconf.command_prefix:
+                mount_path = self.get_mountpoint_path_from_pod()
+                LOG.debug("Backup target mount_path is : " + mount_path)
+                is_snapshot_exist = self.check_snapshot_exist_on_backend_from_pod(
+                    mount_path, self.workload_id, deleted_snapshot_id)
+                LOG.debug("Snapshot does not exist : %s" % is_snapshot_exist)
+            else:
+                mount_path = self.get_mountpoint_path(
+                    ipaddress=tvaultconf.tvault_ip[0],
+                    username=tvaultconf.tvault_username,
+                    password=tvaultconf.tvault_password)
+                LOG.debug("Backup target mount_path is : " + mount_path)
+                is_snapshot_exist = self.check_snapshot_exist_on_backend(
+                    tvaultconf.tvault_ip[0],
+                    tvaultconf.tvault_username,
+                    tvaultconf.tvault_password,
+                    mount_path,
+                    self .workload_id,
+                    deleted_snapshot_id)
+                LOG.debug("Snapshot does not exist : %s" % is_snapshot_exist)
             if not is_snapshot_exist:
                 LOG.debug("First snapshot is deleted from backup target")
                 reporting.add_test_step(


### PR DESCRIPTION
backup target mount points handled in canonical for barbican, workload_policy and multi-attach_volumes suite.

[results-mount_point_multiattach-vol.pdf](https://github.com/trilioData/tempest/files/10091791/results-mount_point_multiattach-vol.pdf)
[results-mountpoint-barbican.pdf](https://github.com/trilioData/tempest/files/10091792/results-mountpoint-barbican.pdf)
[results-mountpoint-workload-policy.pdf](https://github.com/trilioData/tempest/files/10091793/results-mountpoint-workload-policy.pdf)
