### PR TITLE
AUTO-271 Added qemu-guest-agent changes

### DIFF
--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -3791,9 +3791,21 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
 
     def install_qemu(self, ssh):
         try:
-            buildCommand = "sudo apt install qemu-guest-agent"
+            buildCommand = 'sudo sh -c "echo nameserver 8.8.8.8 >> /etc/resolv.conf"'
             stdin, stdout, stderr = ssh.exec_command(buildCommand)
+            LOG.debug(f"dns entry: {stdout.readlines()} \n {stderr.readlines()}")
+            time.sleep(10)
+            buildCommand = "sudo apt update && sudo apt -y install qemu-guest-agent"
+            stdin, stdout, stderr = ssh.exec_command(buildCommand)
+            LOG.debug(f"Install qemu status: {stdout.readlines()} \n {stderr.readlines()}")
             time.sleep(20)
+            buildCommand = "sudo systemctl enable qemu-guest-agent && sudo systemctl start qemu-guest-agent"
+            stdin, stdout, stderr = ssh.exec_command(buildCommand)
+            time.sleep(10)
+            buildCommand = "sudo systemctl status qemu-guest-agent"
+            stdin, stdout, stderr = ssh.exec_command(buildCommand)
+            LOG.debug(f"qemu-guest-agent status: {stdout.readlines()} \n {stderr.readlines()}")
+            time.sleep(10)
         except Exception as e:
             LOG.error("Exception in install_qemu: " + str(e))
 

--- a/tempest/api/workloadmgr/multiattach_volumes/test_multiattach_volumes.py
+++ b/tempest/api/workloadmgr/multiattach_volumes/test_multiattach_volumes.py
@@ -303,8 +303,8 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
                      [test_var + "oneclickrestore_api", 0]]
             reporting.add_test_script(tests[0][0])
             self.kp = self.create_key_pair(tvaultconf.key_pair_name)
-            self.vm_id_1 = self.create_vm(key_pair=self.kp)
-            self.vm_id_2 = self.create_vm(key_pair=self.kp)
+            self.vm_id_1 = self.create_vm(key_pair=self.kp, image_id=CONF.compute.image_ref_alt)
+            self.vm_id_2 = self.create_vm(key_pair=self.kp, image_id=CONF.compute.image_ref_alt)
 
             # find volume_type = multiattach. So that existing multiattach volume type can be used.
             # Get the volume_type_id
@@ -588,7 +588,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
             # Now create volume with derived volume type id...
             self.boot_volume_id = self.create_volume(
                 volume_type_id=vol_type_id, size=tvaultconf.bootfromvol_vol_size,
-                image_id=CONF.compute.image_ref, volume_cleanup=False)
+                image_id=CONF.compute.image_ref_alt, volume_cleanup=False)
             LOG.debug("Bootable Volume ID: " + str(self.boot_volume_id))
             api_version.COMPUTE_MICROVERSION = '2.60'
 

--- a/tempest/api/workloadmgr/restore/test_glanceimage_restore.py
+++ b/tempest/api/workloadmgr/restore/test_glanceimage_restore.py
@@ -113,7 +113,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             reporting.add_test_script(str(__name__)+"_vm_reboot")
             self.image_name = "tempest_test_image"
             self.image_id = self.create_image(image_name=self.image_name,
-                                    image_cleanup=False)
+                                    image_cleanup=True)
             LOG.debug(f"Image ID: {self.image_id}")
             if not self.image_id:
                 raise Exception("Image not created")
@@ -261,22 +261,22 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
             reporting.add_test_script(tests[0])
             self.image_name = "tempest_test_image"
             self.image_id = self.create_image(image_name=self.image_name,
-                                    image_cleanup=False)
+                                    image_cleanup=True)
             LOG.debug(f"Image ID: {self.image_id}")
             if not self.image_id:
                 raise Exception("Image not created")
             self.ssh_username = "ubuntu"
-            self.kp = self.create_key_pair(keypair_cleanup=False)
+            self.kp = self.create_key_pair(keypair_cleanup=True)
             self.old_flavor_id = self.get_flavor_id(tvaultconf.flavor_name)
             self.delete_flavor(self.old_flavor_id)
             self.flavor_id = self.create_flavor(tvaultconf.flavor_name,
-                                    20, 2, 2048, 1536, 1, flavor_cleanup=False)
+                                    20, 2, 2048, 1536, 1, flavor_cleanup=True)
             self.original_flavor_conf = self.get_flavor_details(self.flavor_id)
             LOG.debug(f"original_flavor_conf: {self.original_flavor_conf}")
             self.boot_volume_id = self.create_volume(
                 size=tvaultconf.bootfromvol_vol_size,
                 image_id=self.image_id,
-                volume_cleanup=False)
+                volume_cleanup=True)
             self.set_volume_as_bootable(self.boot_volume_id)
             LOG.debug("Bootable Volume ID : " + str(self.boot_volume_id))
 
@@ -291,7 +291,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
                 image_id="",
                 flavor_id=self.flavor_id,
                 block_mapping_data=self.block_mapping_details,
-                vm_cleanup=False)
+                vm_cleanup=True)
             LOG.debug(f"VM ID : {self.vm_id}")
 
             fip = self.get_floating_ips()
@@ -340,7 +340,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
             # Create flavor before restore
             flavor_id = self.create_flavor(tvaultconf.flavor_name,
-                                           20, 2, 2048, 1536, 1, flavor_cleanup=False)
+                                           20, 2, 2048, 1536, 1, flavor_cleanup=True)
             new_flavor_conf = self.get_flavor_details(flavor_id)
             LOG.debug(f"New_flavor_conf: {new_flavor_conf}")
 
@@ -409,7 +409,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
             # Create flavor before restore
             incr_flavor_id = self.create_flavor(tvaultconf.flavor_name,
-                                                20, 2, 2048, 1536, 1, flavor_cleanup=False)
+                                                20, 2, 2048, 1536, 1, flavor_cleanup=True)
             incr_flavor_conf = self.get_flavor_details(incr_flavor_id)
             LOG.debug(f"incr_flavor_conf: {incr_flavor_conf}")
 
@@ -470,7 +470,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
             # Create flavor before restore
             flavor_id = self.create_flavor(tvaultconf.flavor_name,
-                                           20, 2, 2048, 1536, 1, flavor_cleanup=False)
+                                           20, 2, 2048, 1536, 1, flavor_cleanup=True)
             new_flavor_conf = self.get_flavor_details(flavor_id)
             LOG.debug(f"New_flavor_conf: {new_flavor_conf}")
 
@@ -518,7 +518,7 @@ class WorkloadTest(base.BaseWorkloadmgrTest):
 
             # Create flavor before restore
             flavor_id = self.create_flavor(tvaultconf.flavor_name,
-                                           20, 2, 2048, 1536, 1, flavor_cleanup=False)
+                                           20, 2, 2048, 1536, 1, flavor_cleanup=True)
             incr_flavor_conf = self.get_flavor_details(flavor_id)
             LOG.debug(f"New_flavor_conf: {incr_flavor_conf}")
 

--- a/tempest/prerequisites.py
+++ b/tempest/prerequisites.py
@@ -104,7 +104,7 @@ def inplace(self):
             security_group_id=security_group_id,
             flavor_id=flavor_id,
             key_pair=tvaultconf.key_pair_name,
-            vm_cleanup=True)
+            image_id=CONF.compute.image_ref_alt, vm_cleanup=True)
         self.workload_instances.append(vm_id)
         self.workload_volumes.append(self.volumes_list[0])
         self.attach_volume(str(self.volumes_list[0]), vm_id, device=volumes[0])
@@ -134,6 +134,7 @@ def inplace(self):
 
         ssh = self.SshRemoteMachineConnectionWithRSAKey(
             str(self.floating_ips_list[0]))
+        self.install_qemu(ssh)
         self.execute_command_disk_create(ssh, str(self.floating_ips_list[0]), [
             volumes[0]], [mount_points[0]])
         ssh.close()
@@ -146,6 +147,7 @@ def inplace(self):
 
         ssh = self.SshRemoteMachineConnectionWithRSAKey(
             str(self.floating_ips_list[1]))
+        self.install_qemu(ssh)
         self.execute_command_disk_create(
             ssh, str(self.floating_ips_list[1]), volumes, mount_points)
         ssh.close()


### PR DESCRIPTION
fixed test failures and added change to execute these tests on qemu image if available.

[results-glanceimage-restore.pdf](https://github.com/trilioData/tempest/files/10379347/results-glanceimage-restore.pdf)
[results-ma-imagebooted-qemu.pdf](https://github.com/trilioData/tempest/files/10379348/results-ma-imagebooted-qemu.pdf)
[results-ma-volbooted-qemu-img.pdf](https://github.com/trilioData/tempest/files/10379349/results-ma-volbooted-qemu-img.pdf)
