### PR TITLE
AUTO-289 : Changed the workload type from parallel to serial for Sanity run - stable/5.0

### DIFF
--- a/tempest/api/workloadmgr/base.py
+++ b/tempest/api/workloadmgr/base.py
@@ -589,7 +589,7 @@ class BaseWorkloadmgrTest(tempest.test.BaseTestCase):
     def workload_create(
             self,
             instances,
-            workload_type=tvaultconf.parallel,
+            workload_type=tvaultconf.serial,
             jobschedule={"enabled": False},
             workload_name="",
             workload_cleanup=True,

--- a/tempest/api/workloadmgr/sanity/test_create_full_snapshot.py
+++ b/tempest/api/workloadmgr/sanity/test_create_full_snapshot.py
@@ -55,7 +55,7 @@ class WorkloadsTest(base.BaseWorkloadmgrTest):
     def _create_workload(self, workload_instances, encrypt=False, secret=""):
         time.sleep(5)
         self.workload_id = self.workload_create(
-            workload_instances, tvaultconf.parallel, encryption=encrypt,
+            workload_instances, tvaultconf.serial, encryption=encrypt,
             secret_uuid=secret, workload_cleanup=False)
         self.wait_for_workload_tobe_available(self.workload_id)
         self.workload_status = self.getWorkloadStatus(self.workload_id)

--- a/tempest/prerequisites.py
+++ b/tempest/prerequisites.py
@@ -180,7 +180,7 @@ def inplace(self):
 
         # Create workload and trigger full snapshot
         self.workload_id = self.workload_create(
-            self.workload_instances, tvaultconf.parallel)
+            self.workload_instances, tvaultconf.serial)
         self.snapshot_id = self.workload_snapshot(self.workload_id, True)
         self.wait_for_workload_tobe_available(self.workload_id)
         if (self.getSnapshotStatus(self.workload_id, self.snapshot_id) != "available"):
@@ -332,7 +332,7 @@ def bootfrom_image_with_floating_ips(self):
 
         # Create workload and trigger full snapshot
         self.workload_id = self.workload_create(
-            self.workload_instances, tvaultconf.parallel)
+            self.workload_instances, tvaultconf.serial)
         self.snapshot_id = self.workload_snapshot(self.workload_id, True)
         self.wait_for_workload_tobe_available(self.workload_id)
         if (self.getSnapshotStatus(self.workload_id, self.snapshot_id) != "available"):
@@ -426,7 +426,7 @@ def selective_basic(self):
 
         # Create workload and trigger full snapshot
         self.workload_id = self.workload_create(
-            self.workload_instances, tvaultconf.parallel)
+            self.workload_instances, tvaultconf.serial)
         self.snapshot_id = self.workload_snapshot(self.workload_id, True)
         self.wait_for_workload_tobe_available(self.workload_id)
         if (self.getSnapshotStatus(self.workload_id, self.snapshot_id) != "available"):
@@ -524,7 +524,7 @@ def filesearch(self):
         # Create workload
         self.wid = self.workload_create(
             self.instances_ids,
-            tvaultconf.parallel,
+            tvaultconf.serial,
             workload_name=tvaultconf.workload_name,
             workload_cleanup=False)
         LOG.debug("Workload ID: " + str(self.wid))
@@ -626,7 +626,7 @@ def basic_workload(self):
         self.workload_instances.append(self.vm_id)
         self.wid = self.workload_create(
             self.workload_instances,
-            tvaultconf.parallel,
+            tvaultconf.serial,
             workload_name=self.workload_name,
             workload_cleanup=False)
         LOG.debug("Workload ID: " + str(self.wid))
@@ -665,7 +665,7 @@ def bootfromvol_workload(self):
         # Create workload
         self.workload_id = self.workload_create(
             self.workload_instances,
-            tvaultconf.parallel,
+            tvaultconf.serial,
             workload_cleanup=False)
         if (self.wait_for_workload_tobe_available(self.workload_id) == False):
             reporting.add_test_step("Create_Workload", tvaultconf.FAIL)
@@ -815,7 +815,7 @@ def bootfromvol_workload_medium(self):
         # Create workload
         self.workload_id = self.workload_create(
             self.workload_instances,
-            tvaultconf.parallel,
+            tvaultconf.serial,
             workload_cleanup=False)
         if (self.wait_for_workload_tobe_available(self.workload_id) == False):
             self.exception = "Create_Workload"
@@ -985,7 +985,7 @@ def create_instances_workload_snapshots(self, floating_ip_image, floating_ip_vol
     # Create workload
     self.wid = self.workload_create(
         self.instances_ids,
-        tvaultconf.parallel,
+        tvaultconf.serial,
         workload_name=tvaultconf.workload_name,
         workload_cleanup=False)
     LOG.debug("Workload ID: " + str(self.wid))
@@ -1195,7 +1195,7 @@ def network_topology(self):
 
         self.vms_ids = [x[1] for x in self.vms]
         self.workload_id = self.workload_create(
-            self.vms_ids, tvaultconf.parallel, workload_cleanup=False)
+            self.vms_ids, tvaultconf.serial, workload_cleanup=False)
         LOG.debug("Workload ID: " + str(self.workload_id))
         if(self.workload_id is not None):
             self.wait_for_workload_tobe_available(self.workload_id)

--- a/tempest/tvaultconf.py
+++ b/tempest/tvaultconf.py
@@ -16,6 +16,7 @@ enabled_tests = ["Attached_Volume_Ceph"]
 
 #Id of workload type "parallel"
 parallel="2ddd528d-c9b4-4d7e-8722-cc395140255a"
+serial="f82ce76f-17fe-438b-aa37-7a023058e50d"
 
 #Resources to use from file
 #Please add your resources one on each line in files: tempest/tempest/vms_file, volumes_file, workloads_file


### PR DESCRIPTION
Now the serial type WL is getting created for Sanity run.
You can ignore the restore failure in below result, we have Jira logged for this issue.
http://192.168.1.62:8080/job/TVO-Automation/job/Train/job/RHOSP_16_1_TLS_Multinode-2_Sanity/175/console

![image](https://user-images.githubusercontent.com/54347074/216896103-82080412-3ab2-4c6b-94f5-f54459da1503.png)
